### PR TITLE
feat: add maintained headless bootstrap entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OA07.1 Maintained Headless Bootstrap Entry** (2026-04-09)
+  - Added a maintained `tnh-conductor` CLI and app-layer bootstrap path that loads one workflow, composes the real worktree-backed kernel runtime, and returns canonical run metadata/final-state paths
+  - Added an explicit bootstrap runtime profile for builtin validator mappings and mutable execution policy, while keeping `EVALUATE` and `GATE` fail-closed until real maintained semantic-control implementations land
+  - Added typed execution and validation protocol seams plus focused regressions for happy-path bootstrap, unsupported semantic-step rejection, `ROLLBACK(pre_run)`, agent failure terminal metadata, and default CLI storage roots
+  - Files: `src/tnh_scholar/agent_orchestration/app/`, `src/tnh_scholar/cli_tools/tnh_conductor/`, `src/tnh_scholar/agent_orchestration/execution/`, `src/tnh_scholar/agent_orchestration/validation/`, `src/tnh_scholar/agent_orchestration/kernel/`, `tests/agent_orchestration/test_headless_bootstrap_service.py`, `tests/cli_tools/test_tnh_conductor.py`, `pyproject.toml`
+
 - **CI Constraint Path Hardening** (2026-04-08)
   - Updated the GitHub Actions `PIP_CONSTRAINT` environment variable to use `${{ github.workspace }}` so the CI setuptools cap resolves from a stable absolute workspace path rather than a relative shell cwd
   - Files: `.github/workflows/ci.yml`

--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ This section organizes work into three priority levels based on criticality for 
 
 #### 🚨 OA07.1 Bootstrap Worktree Slice
 
-- **Status**: IN PROGRESS — PR-7 complete; PR-8 is the next bootstrap slice
+- **Status**: IN PROGRESS — PR-7 complete; PR-8 implemented on branch and pending PR
 - **Priority**: HIGHEST (next operational bootstrap slice)
 - **Context**: The maintained OA04.x runtime contracts now include the real OA07.1 worktree runtime boundary. Bootstrap is no longer blocked on workspace isolation; it is now blocked on adding one maintained headless entry point that drives the runtime end to end. Follow [ADR-OA07](/architecture/agent-orchestration/adr/adr-oa07-diff-policy-safety-rails.md) and [ADR-OA07.1](/architecture/agent-orchestration/adr/adr-oa07.1-worktree-lifecycle-and-rollback.md).
 - **Bootstrap Goal**:
@@ -136,7 +136,7 @@ This section organizes work into three priority levels based on criticality for 
     - persist workspace context into canonical run artifacts or run metadata extension
     - tests for worktree creation, mutable-step execution in the worktree root, recorded base state, and `ROLLBACK(pre_run)` semantics
     - keep `NullWorkspaceService` only for tests or explicit non-operational contexts
-  - [ ] **PR-8** `feat/oa07-bootstrap-headless-entry` — Maintained headless bootstrap entry (small/medium, next)
+  - [x] **PR-8** `feat/oa07-bootstrap-headless-entry` — Maintained headless bootstrap entry (small/medium, next)
     - load one workflow
     - create worktree context
     - execute workflow end to end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ tnh-tree = "tnh_scholar.cli_tools.tnh_tree:main"
 sent-split = "tnh_scholar.cli_tools.sent_split.sent_split:main"
 json-srt = "tnh_scholar.cli_tools.json_to_srt.json_to_srt:main"
 srt-translate = "tnh_scholar.cli_tools.srt_translate.srt_translate:main"
+tnh-conductor = "tnh_scholar.cli_tools.tnh_conductor.tnh_conductor:main"
 # EXPERIMENTAL - disabled (agent orchestration paused, see ADR-OA02 addendum)
 # tnh-conductor-spike = "tnh_scholar.cli_tools.tnh_conductor_spike.tnh_conductor_spike:main"
 # tnh-codex-harness = "tnh_scholar.cli_tools.tnh_codex_harness.tnh_codex_harness:main"

--- a/src/tnh_scholar/agent_orchestration/app/__init__.py
+++ b/src/tnh_scholar/agent_orchestration/app/__init__.py
@@ -1,0 +1,29 @@
+"""Maintained application-layer bootstrap surface for agent orchestration."""
+
+from tnh_scholar.agent_orchestration.app.models import (
+    HeadlessBootstrapConfig,
+    HeadlessBootstrapParams,
+    HeadlessBootstrapResult,
+    HeadlessPolicyConfig,
+    HeadlessRunnerConfig,
+    HeadlessStorageConfig,
+    HeadlessValidationConfig,
+)
+from tnh_scholar.agent_orchestration.app.profile import (
+    BootstrapRuntimeProfile,
+    build_bootstrap_runtime_profile,
+)
+from tnh_scholar.agent_orchestration.app.service import HeadlessBootstrapService
+
+__all__ = [
+    "BootstrapRuntimeProfile",
+    "HeadlessBootstrapConfig",
+    "HeadlessBootstrapParams",
+    "HeadlessBootstrapResult",
+    "HeadlessBootstrapService",
+    "HeadlessPolicyConfig",
+    "HeadlessRunnerConfig",
+    "HeadlessStorageConfig",
+    "HeadlessValidationConfig",
+    "build_bootstrap_runtime_profile",
+]

--- a/src/tnh_scholar/agent_orchestration/app/factory.py
+++ b/src/tnh_scholar/agent_orchestration/app/factory.py
@@ -1,0 +1,132 @@
+"""Composition helpers for the maintained headless bootstrap app layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from tnh_scholar.agent_orchestration.app.models import HeadlessBootstrapConfig
+from tnh_scholar.agent_orchestration.common.run_id import strftime_run_id
+from tnh_scholar.agent_orchestration.common.time import utc_now
+from tnh_scholar.agent_orchestration.execution import SubprocessExecutionService
+from tnh_scholar.agent_orchestration.kernel import KernelRunService
+from tnh_scholar.agent_orchestration.kernel.validator import WorkflowValidator
+from tnh_scholar.agent_orchestration.run_artifacts import FilesystemRunArtifactStore
+from tnh_scholar.agent_orchestration.runners import DelegatingRunnerService
+from tnh_scholar.agent_orchestration.runners.adapters.claude_cli import ClaudeCliRunnerAdapter
+from tnh_scholar.agent_orchestration.runners.adapters.codex_cli import CodexCliRunnerAdapter
+from tnh_scholar.agent_orchestration.validation import (
+    HarnessBackendRegistry,
+    HarnessReportLoader,
+    ScriptHarnessBackend,
+    StaticHarnessBackendResolver,
+    StaticValidatorResolver,
+    ValidationService,
+)
+from tnh_scholar.agent_orchestration.workspace import GitWorktreeWorkspaceService
+
+
+@dataclass(frozen=True)
+class SystemClock:
+    """System UTC clock for maintained headless bootstrap runs."""
+
+    def now(self) -> datetime:
+        """Return the current UTC timestamp."""
+        return utc_now()
+
+
+@dataclass(frozen=True)
+class TimestampRunIdGenerator:
+    """Generate compact timestamp run IDs for bootstrap runs."""
+
+    def next_id(self, now: datetime) -> str:
+        """Return a compact timestamp-based run ID."""
+        return strftime_run_id(now, "%Y%m%dT%H%M%SZ")
+
+
+@dataclass(frozen=True)
+class BootstrapKernelBundle:
+    """Maintained collaborators required for one headless bootstrap run."""
+
+    kernel_service: KernelRunService
+    workspace_service: GitWorktreeWorkspaceService
+
+
+@dataclass(frozen=True)
+class BootstrapKernelFactory:
+    """Build the maintained kernel bundle for one headless bootstrap run."""
+
+    config: HeadlessBootstrapConfig
+
+    def build(self) -> BootstrapKernelBundle:
+        """Return the fully assembled maintained kernel bundle."""
+        execution_service = SubprocessExecutionService()
+        workspace_service = GitWorktreeWorkspaceService(
+            repo_root=self.config.repo_root,
+            workspace_root=self.config.storage.workspace_root,
+            base_ref=self.config.base_ref,
+            branch_prefix=self.config.branch_prefix,
+        )
+        kernel_service = KernelRunService(
+            clock=SystemClock(),
+            run_id_generator=TimestampRunIdGenerator(),
+            artifact_store=FilesystemRunArtifactStore(),
+            workspace=workspace_service,
+            runner_service=DelegatingRunnerService(
+                adapters=(
+                    CodexCliRunnerAdapter(
+                        execution_service=execution_service,
+                        executable=self.config.runner.codex_executable,
+                    ),
+                    ClaudeCliRunnerAdapter(
+                        execution_service=execution_service,
+                        executable=self.config.runner.claude_executable,
+                    ),
+                )
+            ),
+            validation_service=ValidationService(
+                resolver=StaticValidatorResolver(
+                    entries=list(self.config.validation.builtin_commands)
+                ),
+                execution_service=execution_service,
+                harness_resolver=StaticHarnessBackendResolver(),
+                backend_registry=HarnessBackendRegistry(
+                    script_backend=ScriptHarnessBackend(
+                        execution_service=execution_service,
+                        report_loader=HarnessReportLoader(),
+                    )
+                ),
+            ),
+            planner_evaluator=_UnsupportedPlannerEvaluator(),
+            gate_approver=_UnsupportedGateApprover(),
+            workflow_validator=WorkflowValidator(),
+            execution_policy_settings=self.config.policy.execution_policy_settings,
+        )
+        return BootstrapKernelBundle(
+            kernel_service=kernel_service,
+            workspace_service=workspace_service,
+        )
+
+
+@dataclass(frozen=True)
+class _UnsupportedPlannerEvaluator:
+    """Fail closed until the maintained evaluator surface is implemented."""
+
+    def evaluate(self, step: object, run_directory: object) -> object:
+        del step, run_directory
+        raise NotImplementedError(
+            "Maintained headless bootstrap does not yet support EVALUATE. "
+            "Use workflows limited to RUN_AGENT, RUN_VALIDATION, ROLLBACK, and STOP."
+        )
+
+
+@dataclass(frozen=True)
+class _UnsupportedGateApprover:
+    """Fail closed until the maintained gate approval surface is implemented."""
+
+    def decide(self, step: object, run_directory: object) -> object:
+        del step, run_directory
+        raise NotImplementedError(
+            "Maintained headless bootstrap does not yet support GATE. "
+            "Use workflows limited to RUN_AGENT, RUN_VALIDATION, ROLLBACK, and STOP."
+        )

--- a/src/tnh_scholar/agent_orchestration/app/factory.py
+++ b/src/tnh_scholar/agent_orchestration/app/factory.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
+from typing import Protocol
 
 from tnh_scholar.agent_orchestration.app.models import HeadlessBootstrapConfig
 from tnh_scholar.agent_orchestration.common.run_id import strftime_run_id
 from tnh_scholar.agent_orchestration.common.time import utc_now
 from tnh_scholar.agent_orchestration.execution import SubprocessExecutionService
-from tnh_scholar.agent_orchestration.kernel import KernelRunService
+from tnh_scholar.agent_orchestration.kernel import GateOutcome, KernelRunService, PlannerDecision
+from tnh_scholar.agent_orchestration.kernel.models import EvaluateStep, GateStep
+from tnh_scholar.agent_orchestration.kernel.protocols import (
+    GateApproverProtocol,
+    PlannerEvaluatorProtocol,
+)
 from tnh_scholar.agent_orchestration.kernel.validator import WorkflowValidator
 from tnh_scholar.agent_orchestration.run_artifacts import FilesystemRunArtifactStore
 from tnh_scholar.agent_orchestration.runners import DelegatingRunnerService
@@ -50,6 +57,13 @@ class BootstrapKernelBundle:
 
     kernel_service: KernelRunService
     workspace_service: GitWorktreeWorkspaceService
+
+
+class BootstrapKernelFactoryProtocol(Protocol):
+    """Build one maintained bootstrap kernel bundle."""
+
+    def build(self) -> BootstrapKernelBundle:
+        """Return the fully assembled maintained bootstrap bundle."""
 
 
 @dataclass(frozen=True)
@@ -109,10 +123,10 @@ class BootstrapKernelFactory:
 
 
 @dataclass(frozen=True)
-class _UnsupportedPlannerEvaluator:
+class _UnsupportedPlannerEvaluator(PlannerEvaluatorProtocol):
     """Fail closed until the maintained evaluator surface is implemented."""
 
-    def evaluate(self, step: object, run_directory: object) -> object:
+    def evaluate(self, step: EvaluateStep, run_directory: Path) -> PlannerDecision:
         del step, run_directory
         raise NotImplementedError(
             "Maintained headless bootstrap does not yet support EVALUATE. "
@@ -121,10 +135,10 @@ class _UnsupportedPlannerEvaluator:
 
 
 @dataclass(frozen=True)
-class _UnsupportedGateApprover:
+class _UnsupportedGateApprover(GateApproverProtocol):
     """Fail closed until the maintained gate approval surface is implemented."""
 
-    def decide(self, step: object, run_directory: object) -> object:
+    def decide(self, step: GateStep, run_directory: Path) -> GateOutcome:
         del step, run_directory
         raise NotImplementedError(
             "Maintained headless bootstrap does not yet support GATE. "

--- a/src/tnh_scholar/agent_orchestration/app/models.py
+++ b/src/tnh_scholar/agent_orchestration/app/models.py
@@ -1,0 +1,76 @@
+"""Typed models for the maintained headless bootstrap app layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from tnh_scholar.agent_orchestration.execution_policy import ExecutionPolicySettings
+from tnh_scholar.agent_orchestration.validation import BuiltinCommandEntry
+from tnh_scholar.agent_orchestration.workspace.models import WorkspaceContext
+
+
+class HeadlessStorageConfig(BaseModel):
+    """Construction-time storage roots for headless bootstrap runs."""
+
+    runs_root: Path
+    workspace_root: Path
+
+    @classmethod
+    def for_repo_root(cls, repo_root: Path) -> "HeadlessStorageConfig":
+        """Return the default storage layout rooted under one repository."""
+        conductor_root = repo_root / ".tnh-conductor"
+        return cls(
+            runs_root=conductor_root / "runs",
+            workspace_root=conductor_root / "worktrees",
+        )
+
+
+class HeadlessRunnerConfig(BaseModel):
+    """Construction-time runner executable config."""
+
+    codex_executable: Path | None = None
+    claude_executable: Path | None = None
+
+
+class HeadlessValidationConfig(BaseModel):
+    """Construction-time builtin validator mapping config."""
+
+    builtin_commands: tuple[BuiltinCommandEntry, ...] = Field(default_factory=tuple)
+
+
+class HeadlessPolicyConfig(BaseModel):
+    """Construction-time execution policy config."""
+
+    execution_policy_settings: ExecutionPolicySettings
+
+
+class HeadlessBootstrapConfig(BaseModel):
+    """Construction-time config for the maintained headless bootstrap path."""
+
+    repo_root: Path
+    storage: HeadlessStorageConfig
+    base_ref: str = "HEAD"
+    branch_prefix: str = "tnh/run-"
+    runner: HeadlessRunnerConfig = Field(default_factory=HeadlessRunnerConfig)
+    validation: HeadlessValidationConfig
+    policy: HeadlessPolicyConfig
+
+
+class HeadlessBootstrapParams(BaseModel):
+    """Per-run parameters for the maintained headless bootstrap path."""
+
+    workflow_path: Path
+
+
+class HeadlessBootstrapResult(BaseModel):
+    """Stable summary returned by the maintained headless bootstrap path."""
+
+    run_id: str
+    workflow_id: str
+    status: str
+    run_directory: Path
+    metadata_path: Path
+    final_state_path: Path
+    workspace_context: WorkspaceContext | None = None

--- a/src/tnh_scholar/agent_orchestration/app/profile.py
+++ b/src/tnh_scholar/agent_orchestration/app/profile.py
@@ -1,0 +1,65 @@
+"""Explicit bootstrap profile assembly for the maintained headless app layer."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from tnh_scholar.agent_orchestration.app.models import (
+    HeadlessPolicyConfig,
+    HeadlessValidationConfig,
+)
+from tnh_scholar.agent_orchestration.execution_policy import (
+    ApprovalPosture,
+    ExecutionPolicySettings,
+    ExecutionPosture,
+    RequestedExecutionPolicy,
+)
+from tnh_scholar.agent_orchestration.validation import BuiltinCommandEntry, BuiltinValidatorId
+
+
+@dataclass(frozen=True)
+class BootstrapRuntimeProfile:
+    """Explicit temporary bootstrap profile for headless maintained runs."""
+
+    validation: HeadlessValidationConfig
+    policy: HeadlessPolicyConfig
+
+
+def build_bootstrap_runtime_profile() -> BootstrapRuntimeProfile:
+    """Return the explicit bootstrap profile used by the maintained CLI."""
+    return BootstrapRuntimeProfile(
+        validation=HeadlessValidationConfig(
+            builtin_commands=_bootstrap_builtin_commands()
+        ),
+        policy=HeadlessPolicyConfig(
+            execution_policy_settings=ExecutionPolicySettings(
+                default_policy=RequestedExecutionPolicy(
+                    execution_posture=ExecutionPosture.workspace_write,
+                    approval_posture=ApprovalPosture.fail_on_prompt,
+                )
+            )
+        ),
+    )
+
+
+def _bootstrap_builtin_commands() -> tuple[BuiltinCommandEntry, ...]:
+    interpreter = Path(sys.executable)
+    return (
+        BuiltinCommandEntry(
+            name=BuiltinValidatorId.tests,
+            executable=interpreter,
+            arguments=("-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py", "-q"),
+        ),
+        BuiltinCommandEntry(
+            name=BuiltinValidatorId.lint,
+            executable=interpreter,
+            arguments=("-m", "ruff", "check", "."),
+        ),
+        BuiltinCommandEntry(
+            name=BuiltinValidatorId.typecheck,
+            executable=interpreter,
+            arguments=("-m", "mypy", "src"),
+        ),
+    )

--- a/src/tnh_scholar/agent_orchestration/app/service.py
+++ b/src/tnh_scholar/agent_orchestration/app/service.py
@@ -1,0 +1,62 @@
+"""Maintained application-layer bootstrap service for headless orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tnh_scholar.agent_orchestration.app.factory import (
+    BootstrapKernelBundle,
+    BootstrapKernelFactory,
+)
+from tnh_scholar.agent_orchestration.app.models import (
+    HeadlessBootstrapConfig,
+    HeadlessBootstrapParams,
+    HeadlessBootstrapResult,
+)
+from tnh_scholar.agent_orchestration.kernel.adapters.workflow_loader import YamlWorkflowLoader
+from tnh_scholar.agent_orchestration.kernel.enums import Opcode
+from tnh_scholar.agent_orchestration.kernel.models import WorkflowDefinition
+
+
+@dataclass(frozen=True)
+class HeadlessBootstrapService:
+    """Load one workflow and run the maintained kernel end to end."""
+
+    config: HeadlessBootstrapConfig
+    workflow_loader: YamlWorkflowLoader = field(default_factory=YamlWorkflowLoader)
+    kernel_factory: BootstrapKernelFactory | None = None
+
+    def run(self, params: HeadlessBootstrapParams) -> HeadlessBootstrapResult:
+        """Execute one maintained headless bootstrap run."""
+        workflow = self.workflow_loader.load(params.workflow_path)
+        self._validate_bootstrap_workflow(workflow)
+        bundle = self._kernel_bundle()
+        run_result = bundle.kernel_service.run(workflow, self.config.storage.runs_root)
+        return HeadlessBootstrapResult(
+            run_id=run_result.run_id,
+            workflow_id=run_result.workflow_id,
+            status=run_result.status.value,
+            run_directory=run_result.run_directory,
+            metadata_path=run_result.metadata_path,
+            final_state_path=run_result.final_state_path,
+            workspace_context=bundle.workspace_service.current_context(),
+        )
+
+    def _kernel_bundle(self) -> BootstrapKernelBundle:
+        factory = self.kernel_factory
+        if factory is None:
+            factory = BootstrapKernelFactory(config=self.config)
+        return factory.build()
+
+    def _validate_bootstrap_workflow(self, workflow: WorkflowDefinition) -> None:
+        unsupported = [
+            str(step.opcode)
+            for step in workflow.steps
+            if str(step.opcode) in {Opcode.evaluate.value, Opcode.gate.value}
+        ]
+        if unsupported:
+            joined = ", ".join(unsupported)
+            raise ValueError(
+                "Maintained headless bootstrap does not support semantic control steps yet: "
+                f"{joined}."
+            )

--- a/src/tnh_scholar/agent_orchestration/app/service.py
+++ b/src/tnh_scholar/agent_orchestration/app/service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from tnh_scholar.agent_orchestration.app.factory import (
     BootstrapKernelBundle,
     BootstrapKernelFactory,
+    BootstrapKernelFactoryProtocol,
 )
 from tnh_scholar.agent_orchestration.app.models import (
     HeadlessBootstrapConfig,
@@ -24,7 +25,7 @@ class HeadlessBootstrapService:
 
     config: HeadlessBootstrapConfig
     workflow_loader: YamlWorkflowLoader = field(default_factory=YamlWorkflowLoader)
-    kernel_factory: BootstrapKernelFactory | None = None
+    kernel_factory: BootstrapKernelFactoryProtocol | None = None
 
     def run(self, params: HeadlessBootstrapParams) -> HeadlessBootstrapResult:
         """Execute one maintained headless bootstrap run."""
@@ -52,7 +53,7 @@ class HeadlessBootstrapService:
         unsupported = [
             str(step.opcode)
             for step in workflow.steps
-            if str(step.opcode) in {Opcode.evaluate.value, Opcode.gate.value}
+            if step.opcode in {Opcode.evaluate, Opcode.gate}
         ]
         if unsupported:
             joined = ", ".join(unsupported)

--- a/src/tnh_scholar/agent_orchestration/execution/__init__.py
+++ b/src/tnh_scholar/agent_orchestration/execution/__init__.py
@@ -12,6 +12,7 @@ from tnh_scholar.agent_orchestration.execution.models import (
     PythonScriptInvocation,
     TimeoutPolicy,
 )
+from tnh_scholar.agent_orchestration.execution.protocols import ExecutionServiceProtocol
 from tnh_scholar.agent_orchestration.execution.service import SubprocessExecutionService
 
 __all__ = [
@@ -19,6 +20,7 @@ __all__ = [
     "ExecutionOutputCapturePolicy",
     "ExecutionRequest",
     "ExecutionResult",
+    "ExecutionServiceProtocol",
     "ExecutionTermination",
     "ExplicitEnvironmentPolicy",
     "InheritParentEnvironmentPolicy",

--- a/src/tnh_scholar/agent_orchestration/execution/models.py
+++ b/src/tnh_scholar/agent_orchestration/execution/models.py
@@ -67,6 +67,11 @@ class ExplicitEnvironmentPolicy(BaseModel):
     kind: Literal["explicit"] = "explicit"
     values: dict[str, str] = Field(default_factory=dict)
 
+    @classmethod
+    def empty(cls) -> "ExplicitEnvironmentPolicy":
+        """Return an explicit empty environment policy."""
+        return cls()
+
 
 class IsolatedEnvironmentPolicy(BaseModel):
     """Start from an empty environment and allowlist values."""

--- a/src/tnh_scholar/agent_orchestration/execution/protocols.py
+++ b/src/tnh_scholar/agent_orchestration/execution/protocols.py
@@ -1,0 +1,14 @@
+"""Protocols for the execution subsystem."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from tnh_scholar.agent_orchestration.execution.models import ExecutionRequest, ExecutionResult
+
+
+class ExecutionServiceProtocol(Protocol):
+    """Execute one trusted execution request."""
+
+    def run(self, request: ExecutionRequest) -> ExecutionResult:
+        """Execute one trusted request and return the normalized result."""

--- a/src/tnh_scholar/agent_orchestration/kernel/models.py
+++ b/src/tnh_scholar/agent_orchestration/kernel/models.py
@@ -129,6 +129,8 @@ class KernelRunResult(BaseModel):
     status: MechanicalOutcome
     last_step_id: str
     run_directory: Path
+    metadata_path: Path
+    final_state_path: Path
 
 
 __all__ = [

--- a/src/tnh_scholar/agent_orchestration/kernel/service.py
+++ b/src/tnh_scholar/agent_orchestration/kernel/service.py
@@ -168,6 +168,8 @@ class KernelRunService:
                     status=MechanicalOutcome.completed,
                     last_step_id=step.id,
                     run_directory=context.run_directory,
+                    metadata_path=paths.metadata_path,
+                    final_state_path=paths.final_state_path,
                 )
             step_started_at = self.clock.now()
             policy_record = self._persist_step_policy(step=step, context=context)

--- a/src/tnh_scholar/agent_orchestration/validation/__init__.py
+++ b/src/tnh_scholar/agent_orchestration/validation/__init__.py
@@ -4,6 +4,7 @@ from tnh_scholar.agent_orchestration.validation.backends import (
     HarnessReportLoader,
     ScriptHarnessBackend,
 )
+from tnh_scholar.agent_orchestration.validation.errors import ValidationArtifactMergeError
 from tnh_scholar.agent_orchestration.validation.models import (
     BackendFamily,
     BuiltinValidationSpec,
@@ -38,6 +39,7 @@ __all__ = [
     "HarnessBackendRequest",
     "HarnessBackendResult",
     "HarnessReport",
+    "ValidationArtifactMergeError",
     "ScriptHarnessBackend",
     "HarnessValidationSpec",
     "HarnessReportLoader",

--- a/src/tnh_scholar/agent_orchestration/validation/errors.py
+++ b/src/tnh_scholar/agent_orchestration/validation/errors.py
@@ -1,0 +1,9 @@
+"""Domain errors for the validation subsystem."""
+
+from __future__ import annotations
+
+from tnh_scholar.exceptions import TnhScholarError
+
+
+class ValidationArtifactMergeError(TnhScholarError):
+    """Raised when validation artifacts cannot be merged safely."""

--- a/src/tnh_scholar/agent_orchestration/validation/protocols.py
+++ b/src/tnh_scholar/agent_orchestration/validation/protocols.py
@@ -37,6 +37,13 @@ class HarnessBackendProtocol(Protocol):
         """Execute one harness request and normalize outputs."""
 
 
+class HarnessBackendRegistryProtocol(Protocol):
+    """Resolve one backend implementation for a harness family."""
+
+    def resolve(self, family: object) -> HarnessBackendProtocol:
+        """Return the backend implementation for one harness family."""
+
+
 class ValidationServiceProtocol(Protocol):
     """Execute a validation step."""
 

--- a/src/tnh_scholar/agent_orchestration/validation/service.py
+++ b/src/tnh_scholar/agent_orchestration/validation/service.py
@@ -11,9 +11,10 @@ from pydantic import BaseModel, Field
 from tnh_scholar.agent_orchestration.execution import (
     CliExecutableInvocation,
     ExecutionRequest,
+    ExecutionServiceProtocol,
     ExplicitEnvironmentPolicy,
-    SubprocessExecutionService,
 )
+from tnh_scholar.agent_orchestration.validation.errors import ValidationArtifactMergeError
 from tnh_scholar.agent_orchestration.validation.models import (
     BackendFamily,
     BuiltinValidationSpec,
@@ -31,6 +32,7 @@ from tnh_scholar.agent_orchestration.validation.models import (
 )
 from tnh_scholar.agent_orchestration.validation.protocols import (
     HarnessBackendProtocol,
+    HarnessBackendRegistryProtocol,
     HarnessBackendResolverProtocol,
     ValidationServiceProtocol,
     ValidatorResolverProtocol,
@@ -65,7 +67,7 @@ class StaticValidatorResolver(ValidatorResolverProtocol):
                         arguments=entry.arguments,
                     ),
                     working_directory=working_directory,
-                    environment_policy=ExplicitEnvironmentPolicy(values={}),
+                    environment_policy=ExplicitEnvironmentPolicy.empty(),
                 )
         raise ValueError(f"Unknown builtin validator: {spec.name.value}")
 
@@ -89,9 +91,10 @@ class StaticHarnessBackendResolver(HarnessBackendResolverProtocol):
                     working_directory=working_directory,
                     artifact_patterns=tuple(spec.artifacts),
                     timeout_seconds=spec.timeout_seconds,
-                    environment_policy=ExplicitEnvironmentPolicy(values={}),
+                    environment_policy=ExplicitEnvironmentPolicy.empty(),
                 )
-        raise ValueError(f"Unsupported harness validator: {spec.name.value}")
+            case _:
+                raise ValueError(f"Unsupported harness validator: {spec.name.value}")
 
 
 @dataclass(frozen=True)
@@ -114,9 +117,9 @@ class ValidationService(ValidationServiceProtocol):
     """Execute validation steps using the execution subsystem."""
 
     resolver: ValidatorResolverProtocol
-    execution_service: SubprocessExecutionService
+    execution_service: ExecutionServiceProtocol
     harness_resolver: HarnessBackendResolverProtocol
-    backend_registry: HarnessBackendRegistry
+    backend_registry: HarnessBackendRegistryProtocol
 
     def run(self, request: ValidationStepRequest) -> ValidationResult:
         """Execute all validators in a step."""
@@ -208,7 +211,9 @@ class ValidationService(ValidationServiceProtocol):
         if current is None:
             return new_value
         if current.media_type != new_value.media_type:
-            raise ValueError("Validation text artifacts must share a media type.")
+            raise ValidationArtifactMergeError(
+                "Validation text artifacts must share a media type."
+            )
         combined = self._join_text(current.content, new_value.content)
         return ValidationTextArtifact(
             filename=fallback_filename,

--- a/src/tnh_scholar/cli_tools/tnh_conductor/__init__.py
+++ b/src/tnh_scholar/cli_tools/tnh_conductor/__init__.py
@@ -1,0 +1,5 @@
+"""CLI package for the maintained tnh-conductor entry point."""
+
+from tnh_scholar.cli_tools.tnh_conductor.tnh_conductor import app, main
+
+__all__ = ["app", "main"]

--- a/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
+++ b/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
@@ -1,0 +1,118 @@
+"""Typer entrypoint for the maintained tnh-conductor CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from tnh_scholar.agent_orchestration.app import (
+    HeadlessBootstrapConfig,
+    HeadlessBootstrapParams,
+    HeadlessBootstrapService,
+    HeadlessRunnerConfig,
+    HeadlessStorageConfig,
+    build_bootstrap_runtime_profile,
+)
+
+app = typer.Typer(
+    name="tnh-conductor",
+    help="Maintained local/headless workflow bootstrap runner.",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def conductor_app() -> None:
+    """Expose `tnh-conductor` as a command group."""
+
+
+@app.command("run")
+def run_command(
+    workflow: Path = typer.Option(
+        ...,
+        "--workflow",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        help="Workflow YAML file to execute.",
+    ),
+    repo_root: Path = typer.Option(
+        Path.cwd(),
+        "--repo-root",
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Repository root for the managed worktree run.",
+    ),
+    runs_root: Path | None = typer.Option(
+        None,
+        "--runs-root",
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Optional override for the canonical runs root.",
+    ),
+    workspace_root: Path | None = typer.Option(
+        None,
+        "--workspace-root",
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Optional override for the managed worktree root.",
+    ),
+    base_ref: str = typer.Option("HEAD", "--base-ref", help="Committed git base ref for the run."),
+    codex_executable: Path | None = typer.Option(
+        None,
+        "--codex-executable",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Optional explicit path to the Codex executable.",
+    ),
+    claude_executable: Path | None = typer.Option(
+        None,
+        "--claude-executable",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Optional explicit path to the Claude executable.",
+    ),
+) -> None:
+    """Execute one maintained local/headless bootstrap run."""
+    resolved_repo_root = repo_root.resolve()
+    default_storage = HeadlessStorageConfig.for_repo_root(resolved_repo_root)
+    runtime_profile = build_bootstrap_runtime_profile()
+    storage = HeadlessStorageConfig(
+        runs_root=default_storage.runs_root if runs_root is None else runs_root,
+        workspace_root=default_storage.workspace_root if workspace_root is None else workspace_root,
+    )
+    service = HeadlessBootstrapService(
+        config=HeadlessBootstrapConfig(
+            repo_root=resolved_repo_root,
+            storage=storage,
+            base_ref=base_ref,
+            runner=HeadlessRunnerConfig(
+                codex_executable=codex_executable,
+                claude_executable=claude_executable,
+            ),
+            validation=runtime_profile.validation,
+            policy=runtime_profile.policy,
+        )
+    )
+    try:
+        result = service.run(HeadlessBootstrapParams(workflow_path=workflow))
+    except Exception as error:
+        typer.echo(str(error), err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(result.model_dump_json())
+
+
+def main() -> None:
+    """Dispatch to the Typer app."""
+    app()

--- a/tests/agent_orchestration/test_headless_bootstrap_service.py
+++ b/tests/agent_orchestration/test_headless_bootstrap_service.py
@@ -1,0 +1,415 @@
+"""Tests for the maintained headless bootstrap service."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+from tnh_scholar.agent_orchestration.app import (
+    HeadlessBootstrapConfig,
+    HeadlessBootstrapParams,
+    HeadlessBootstrapService,
+    HeadlessRunnerConfig,
+    HeadlessStorageConfig,
+    build_bootstrap_runtime_profile,
+)
+from tnh_scholar.agent_orchestration.run_artifacts.models import ArtifactRole, StepManifest
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", "-C", str(repo_root), *args),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    raise AssertionError(result.stderr.strip())
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _git(repo_root, "init", "-b", "main")
+    _git(repo_root, "config", "user.name", "Test User")
+    _git(repo_root, "config", "user.email", "test@example.com")
+    (repo_root / "README.md").write_text("bootstrap repo\n", encoding="utf-8")
+    _git(repo_root, "add", "README.md")
+    _git(repo_root, "commit", "-m", "initial")
+    return repo_root
+
+
+def _write_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: bootstrap-workflow
+            version: 1
+            description: Maintained bootstrap test
+            entry_step: agent
+            steps:
+              - id: agent
+                opcode: RUN_AGENT
+                agent: codex
+                prompt: create validation harness
+                routes:
+                  completed: validate
+              - id: validate
+                opcode: RUN_VALIDATION
+                run:
+                  - kind: harness
+                    name: generated_harness
+                routes:
+                  completed: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_evaluate_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: evaluate-bootstrap
+            version: 1
+            description: Unsupported evaluate test
+            entry_step: evaluate
+            steps:
+              - id: evaluate
+                opcode: EVALUATE
+                prompt: assess evidence
+                routes:
+                  success: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_gate_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: gate-bootstrap
+            version: 1
+            description: Unsupported gate test
+            entry_step: gate
+            steps:
+              - id: gate
+                opcode: GATE
+                gate: requires_approval
+                routes:
+                  gate_approved: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_rollback_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: rollback-bootstrap
+            version: 1
+            description: Rollback bootstrap test
+            entry_step: agent
+            steps:
+              - id: agent
+                opcode: RUN_AGENT
+                agent: codex
+                prompt: create mutable file
+                routes:
+                  completed: rollback
+              - id: rollback
+                opcode: ROLLBACK
+                target: pre_run
+                routes:
+                  completed: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_agent_failure_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: failure-bootstrap
+            version: 1
+            description: Agent failure bootstrap test
+            entry_step: agent
+            steps:
+              - id: agent
+                opcode: RUN_AGENT
+                agent: codex
+                prompt: fail the run
+                routes:
+                  completed: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_codex_stub(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            #!/bin/sh
+            response_path=""
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                response_path="$2"
+                shift 2
+                continue
+              fi
+              shift 1
+            done
+            cat <<'EOF' > bootstrap-output.txt
+            changed by bootstrap stub
+            EOF
+            cat <<'EOF' > generated_harness.py
+            from pathlib import Path
+            Path("harness_report.json").write_text('{"proposed_goldens": []}', encoding="utf-8")
+            print("validation ok")
+            EOF
+            printf 'done\\n' > "$response_path"
+            printf '{"type":"message","text":"bootstrap stub transcript"}\\n'
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _write_mutating_codex_stub(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            #!/bin/sh
+            response_path=""
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                response_path="$2"
+                shift 2
+                continue
+              fi
+              shift 1
+            done
+            printf 'dirty\\n' > rollback-target.txt
+            printf 'done\\n' > "$response_path"
+            printf '{"type":"message","text":"rollback transcript"}\\n'
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _write_failing_codex_stub(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            #!/bin/sh
+            response_path=""
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                response_path="$2"
+                shift 2
+                continue
+              fi
+              shift 1
+            done
+            printf 'partial\\n' > "$response_path"
+            printf '{"type":"message","text":"failure transcript"}\\n'
+            exit 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _read_manifest(run_directory: Path, step_id: str) -> StepManifest:
+    path = run_directory / "artifacts" / step_id / "manifest.json"
+    return StepManifest.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _bootstrap_config(
+    *,
+    repo_root: Path,
+    runs_root: Path,
+    workspace_root: Path,
+    codex_executable: Path | None = None,
+) -> HeadlessBootstrapConfig:
+    runtime_profile = build_bootstrap_runtime_profile()
+    return HeadlessBootstrapConfig(
+        repo_root=repo_root,
+        storage=HeadlessStorageConfig(
+            runs_root=runs_root,
+            workspace_root=workspace_root,
+        ),
+        base_ref="main",
+        runner=HeadlessRunnerConfig(codex_executable=codex_executable),
+        validation=runtime_profile.validation,
+        policy=runtime_profile.policy,
+    )
+
+
+def test_headless_bootstrap_service_runs_workflow_in_managed_worktree(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow.yaml"
+    codex_stub = tmp_path / "codex-stub.sh"
+    _write_workflow(workflow_path)
+    _write_codex_stub(codex_stub)
+
+    service = HeadlessBootstrapService(
+        config=_bootstrap_config(
+            repo_root=repo_root,
+            runs_root=tmp_path / "runs",
+            workspace_root=tmp_path / "worktrees",
+            codex_executable=codex_stub,
+        ),
+    )
+
+    result = service.run(HeadlessBootstrapParams(workflow_path=workflow_path))
+
+    assert result.status == "completed"
+    assert result.metadata_path.exists()
+    assert result.final_state_path.exists()
+    assert result.workspace_context is not None
+    assert result.workspace_context.worktree_path != result.run_directory
+    assert result.workspace_context.worktree_path.parent == tmp_path / "worktrees"
+    assert (result.workspace_context.worktree_path / "bootstrap-output.txt").read_text(
+        encoding="utf-8"
+    ) == "changed by bootstrap stub\n"
+    assert not (result.run_directory / "bootstrap-output.txt").exists()
+
+    metadata = json.loads(result.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["workflow_id"] == "bootstrap-workflow"
+    assert metadata["termination"] == "completed"
+    assert metadata["workspace_context"]["base_ref"] == "main"
+    assert metadata["workspace_context"]["worktree_path"] == str(
+        result.workspace_context.worktree_path
+    )
+    assert result.final_state_path.read_text(encoding="utf-8").strip() == "completed:STOP"
+
+    agent_manifest = _read_manifest(result.run_directory, "agent")
+    validate_manifest = _read_manifest(result.run_directory, "validate")
+    assert agent_manifest.artifact_for_role(ArtifactRole.runner_transcript) is not None
+    assert agent_manifest.artifact_for_role(ArtifactRole.runner_final_response) is not None
+    assert validate_manifest.artifact_for_role(ArtifactRole.validation_report) is not None
+    assert validate_manifest.artifact_for_role(ArtifactRole.validation_stdout) is not None
+
+
+def test_headless_bootstrap_service_rejects_evaluate_and_gate_steps(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow-evaluate.yaml"
+    _write_evaluate_workflow(workflow_path)
+    service = HeadlessBootstrapService(
+        config=_bootstrap_config(
+            repo_root=repo_root,
+            runs_root=tmp_path / "runs",
+            workspace_root=tmp_path / "worktrees",
+        ),
+    )
+
+    try:
+        service.run(HeadlessBootstrapParams(workflow_path=workflow_path))
+    except ValueError as error:
+        assert "does not support semantic control steps yet" in str(error)
+        assert "EVALUATE" in str(error)
+        return
+    raise AssertionError("Expected bootstrap service to reject EVALUATE step")
+
+
+def test_headless_bootstrap_service_rejects_gate_steps(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow-gate.yaml"
+    _write_gate_workflow(workflow_path)
+    service = HeadlessBootstrapService(
+        config=_bootstrap_config(
+            repo_root=repo_root,
+            runs_root=tmp_path / "runs",
+            workspace_root=tmp_path / "worktrees",
+        ),
+    )
+
+    try:
+        service.run(HeadlessBootstrapParams(workflow_path=workflow_path))
+    except ValueError as error:
+        assert "does not support semantic control steps yet" in str(error)
+        assert "GATE" in str(error)
+        return
+    raise AssertionError("Expected bootstrap service to reject GATE step")
+
+
+def test_headless_bootstrap_service_supports_pre_run_rollback(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow-rollback.yaml"
+    codex_stub = tmp_path / "codex-rollback-stub.sh"
+    _write_rollback_workflow(workflow_path)
+    _write_mutating_codex_stub(codex_stub)
+    service = HeadlessBootstrapService(
+        config=_bootstrap_config(
+            repo_root=repo_root,
+            runs_root=tmp_path / "runs",
+            workspace_root=tmp_path / "worktrees",
+            codex_executable=codex_stub,
+        ),
+    )
+
+    result = service.run(HeadlessBootstrapParams(workflow_path=workflow_path))
+
+    assert result.workspace_context is not None
+    assert not (result.workspace_context.worktree_path / "rollback-target.txt").exists()
+
+
+def test_headless_bootstrap_service_persists_terminal_metadata_on_agent_failure(
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow-failure.yaml"
+    codex_stub = tmp_path / "codex-failure-stub.sh"
+    runs_root = tmp_path / "runs"
+    _write_agent_failure_workflow(workflow_path)
+    _write_failing_codex_stub(codex_stub)
+    service = HeadlessBootstrapService(
+        config=_bootstrap_config(
+            repo_root=repo_root,
+            runs_root=runs_root,
+            workspace_root=tmp_path / "worktrees",
+            codex_executable=codex_stub,
+        ),
+    )
+
+    try:
+        service.run(HeadlessBootstrapParams(workflow_path=workflow_path))
+    except Exception as error:
+        assert "No route for outcome" in str(error)
+    else:
+        raise AssertionError("Expected bootstrap service to fail on unmapped runner error")
+
+    run_directories = list(runs_root.iterdir())
+    assert len(run_directories) == 1
+    run_directory = run_directories[0]
+    metadata = json.loads((run_directory / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["termination"] == "error"
+    assert metadata["last_step_id"] == "agent"
+    assert (run_directory / "final-state.txt").read_text(encoding="utf-8").strip() == "error:agent"

--- a/tests/cli_tools/test_tnh_conductor.py
+++ b/tests/cli_tools/test_tnh_conductor.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+from typer.testing import CliRunner
+
+from tnh_scholar.cli_tools.tnh_conductor import tnh_conductor
+
+runner = CliRunner(mix_stderr=False)
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", "-C", str(repo_root), *args),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    raise AssertionError(result.stderr.strip())
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _git(repo_root, "init", "-b", "main")
+    _git(repo_root, "config", "user.name", "Test User")
+    _git(repo_root, "config", "user.email", "test@example.com")
+    (repo_root / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(repo_root, "add", "tracked.txt")
+    _git(repo_root, "commit", "-m", "initial")
+    return repo_root
+
+
+def _write_workflow(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            workflow_id: cli-bootstrap
+            version: 1
+            description: CLI bootstrap test
+            entry_step: agent
+            steps:
+              - id: agent
+                opcode: RUN_AGENT
+                agent: codex
+                prompt: write one file
+                routes:
+                  completed: STOP
+              - id: STOP
+                opcode: STOP
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_codex_stub(path: Path) -> None:
+    path.write_text(
+        dedent(
+            """\
+            #!/bin/sh
+            response_path=""
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                response_path="$2"
+                shift 2
+                continue
+              fi
+              shift 1
+            done
+            cat <<'EOF' > cli-output.txt
+            changed by cli stub
+            EOF
+            printf 'done\\n' > "$response_path"
+            printf '{"type":"message","text":"cli transcript"}\\n'
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_tnh_conductor_run_outputs_bootstrap_summary(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow.yaml"
+    runs_root = tmp_path / "runs"
+    workspace_root = tmp_path / "worktrees"
+    codex_stub = tmp_path / "codex-stub.sh"
+    _write_workflow(workflow_path)
+    _write_codex_stub(codex_stub)
+
+    result = runner.invoke(
+        tnh_conductor.app,
+        [
+            "run",
+            "--workflow",
+            str(workflow_path),
+            "--repo-root",
+            str(repo_root),
+            "--runs-root",
+            str(runs_root),
+            "--workspace-root",
+            str(workspace_root),
+            "--base-ref",
+            "main",
+            "--codex-executable",
+            str(codex_stub),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["workflow_id"] == "cli-bootstrap"
+    assert payload["status"] == "completed"
+    assert Path(payload["metadata_path"]).exists()
+    assert Path(payload["final_state_path"]).exists()
+    assert Path(payload["workspace_context"]["worktree_path"]).parent == workspace_root
+
+
+def test_tnh_conductor_run_uses_default_storage_roots(tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    workflow_path = tmp_path / "workflow-defaults.yaml"
+    codex_stub = tmp_path / "codex-default-stub.sh"
+    _write_workflow(workflow_path)
+    _write_codex_stub(codex_stub)
+
+    result = runner.invoke(
+        tnh_conductor.app,
+        [
+            "run",
+            "--workflow",
+            str(workflow_path),
+            "--repo-root",
+            str(repo_root),
+            "--base-ref",
+            "main",
+            "--codex-executable",
+            str(codex_stub),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert Path(payload["run_directory"]).parent == repo_root / ".tnh-conductor" / "runs"
+    assert Path(payload["workspace_context"]["worktree_path"]).parent == (
+        repo_root / ".tnh-conductor" / "worktrees"
+    )


### PR DESCRIPTION
## Summary
- add the maintained tnh-conductor headless bootstrap path and app-layer composition root
- compose the real worktree-backed kernel runtime through an explicit bootstrap runtime profile
- return canonical run metadata and final-state paths from the maintained bootstrap entry
- add focused tests for bootstrap happy path, unsupported semantic-step rejection, rollback, failure metadata, and default CLI storage

## Scope Notes
- EVALUATE and GATE intentionally fail closed in this slice until maintained semantic-control implementations land
- the directional bootstrap memo was moved out of the branch workspace and is not included in this PR

## Validation
- make pr-check
- poetry run python -m ruff check src/tnh_scholar/agent_orchestration/execution src/tnh_scholar/agent_orchestration/validation src/tnh_scholar/agent_orchestration/app src/tnh_scholar/cli_tools/tnh_conductor tests/agent_orchestration/test_oa07_execution_validation_kernel.py tests/agent_orchestration/test_headless_bootstrap_service.py tests/cli_tools/test_tnh_conductor.py
- poetry run pytest -q tests/agent_orchestration/test_oa07_execution_validation_kernel.py tests/agent_orchestration/test_headless_bootstrap_service.py tests/cli_tools/test_tnh_conductor.py