### PR TITLE
Harden tnh-gen completion and run pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **tnh-gen Completion Outcome and Run Robustness** (2026-04-18)
+  - Added typed completion outcomes, structured failure payloads, and adapter diagnostics across the GenAI service and `tnh-gen run`
+  - Hardened the OpenAI adapter against empty, missing, and unsupported response shapes instead of silently returning success-shaped empty text
+  - Updated `tnh-gen run` to branch on succeeded/incomplete/failed outcomes, preserve input frontmatter in output files, and support direct `--prompt-dir` forwarding for one-off runs
+  - Added focused regression coverage for adapter failure mapping, failed/incomplete run behavior, budget blocking, and frontmatter/provenance handling
+  - Files: `src/tnh_scholar/gen_ai_service/`, `src/tnh_scholar/cli_tools/tnh_gen/`, `src/tnh_scholar/metadata/metadata.py`, `tests/gen_ai_service/`, `tests/cli_tools/test_tnh_gen*.py`
+
 - **Codex Headless Experiment Docs Refresh** (2026-04-13)
   - Expanded the headless communication report and experiment plan with native subagent findings, low-noise execution guidance, and a clearer next-experiment sequence
   - Added supervisory shell-trial operator docs plus a repo-local Codex profile and wrapper-script options used by the documented experiment path

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ updated: "2026-04-13"
 
 Roadmap tracking the highest-priority TNH Scholar tasks and release blockers.
 
-> **Last Updated**: 2026-04-13 (headless communication docs refreshed; bootstrap-proof slice still next)
+> **Last Updated**: 2026-04-18 (tnh-gen completion/run robustness slice landed; bootstrap-proof workflow still next)
 > **Version**: 0.3.1 (Alpha)
 > **Status**: Active Development - Bootstrap path complete, production hardening phase
 >
@@ -285,9 +285,9 @@ docs/architecture/jvb-viewer/adr/
 - **M3**: Structure cues — columns, heading levels, emphasis flags captured and rendered
 - **M4**: Beta — section-level navigation, export HTML, light theming
 
-#### 🔮 Add `--prompt-dir` Global Flag to tnh-gen
+#### ✅ Add `--prompt-dir` Global Flag to tnh-gen — *Completed 2026-04-18*
 
-- **Status**: NOT STARTED
+- **Status**: COMPLETE
 - **Priority**: HIGH (improves tnh-gen UX for one-off operations and testing)
 - **Estimate**: 1-2 hours
 - **Context**: Users need convenient way to override prompt catalog directory for one-off CLI calls without setting environment variables or creating temp config files
@@ -297,10 +297,10 @@ docs/architecture/jvb-viewer/adr/
   - Environment variable: `TNH_PROMPT_DIR=/path tnh-gen list` (awkward)
   - Temp config file: `tnh-gen --config /tmp/config.yaml list` (verbose)
 - **Deliverables**:
-  - [ ] Add `--prompt-dir` flag to `cli_callback()` in `src/tnh_scholar/cli_tools/tnh_gen/tnh_gen.py:26`
-  - [ ] Update `config_loader.py` to handle prompt directory override at CLI precedence level
-  - [ ] Update `ConfigData` type to accept `prompt_catalog_dir` override
-  - [ ] Add unit tests for flag precedence (CLI flag > workspace > user > env)
+  - [x] Add `--prompt-dir` flag to `cli_callback()` in `src/tnh_scholar/cli_tools/tnh_gen/tnh_gen.py:26`
+  - [x] Update `config_loader.py` to handle prompt directory override at CLI precedence level
+  - [x] Update `ConfigData` type to accept `prompt_catalog_dir` override
+  - [x] Add unit tests for flag precedence (CLI flag > workspace > user > env)
   - [ ] Update help text and CLI reference documentation
   - [ ] Update `docs/cli-reference/tnh-gen.md` global flags section
 - **Files to Modify**:

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
@@ -9,9 +9,10 @@ from uuid import uuid4
 import typer
 
 from tnh_scholar.cli_tools.tnh_gen.config_loader import CLIConfig, load_config
-from tnh_scholar.cli_tools.tnh_gen.errors import emit_trace_id, render_error
+from tnh_scholar.cli_tools.tnh_gen.errors import ExitCode, emit_trace_id, render_error
 from tnh_scholar.cli_tools.tnh_gen.factory import ServiceFactory, ServiceOverrides
 from tnh_scholar.cli_tools.tnh_gen.output.formatter import render_output
+from tnh_scholar.cli_tools.tnh_gen.output.human_formatter import format_human_friendly_error
 from tnh_scholar.cli_tools.tnh_gen.output.policy import resolve_output_format, validate_run_format
 from tnh_scholar.cli_tools.tnh_gen.output.provenance import write_output_file
 from tnh_scholar.cli_tools.tnh_gen.state import OutputFormat, ctx
@@ -19,15 +20,24 @@ from tnh_scholar.cli_tools.tnh_gen.types import (
     ConfigData,
     ConfigMeta,
     PolicyApplied,
+    RunAdapterDiagnosticsPayload,
+    RunFailurePayload,
+    RunOutcomePayload,
     RunProvenancePayload,
     RunResultPayload,
-    RunSuccessPayload,
     RunUsagePayload,
     VariableMap,
 )
 from tnh_scholar.exceptions import ConfigurationError, ValidationError
-from tnh_scholar.gen_ai_service.models.domain import CompletionEnvelope, RenderRequest
+from tnh_scholar.gen_ai_service.models.domain import (
+    CompletionEnvelope,
+    CompletionFailure,
+    CompletionOutcomeStatus,
+    RenderRequest,
+)
+from tnh_scholar.gen_ai_service.models.errors import SafetyBlocked
 from tnh_scholar.gen_ai_service.protocols import GenAIServiceProtocol
+from tnh_scholar.metadata import Frontmatter, Metadata
 from tnh_scholar.prompt_system.domain.models import PromptMetadata
 
 logger = logging.getLogger(__name__)
@@ -41,6 +51,21 @@ app = typer.Typer(help="Execute a prompt with variable substitution.", invoke_wi
 class TnhGenCLIOptions:
     """Encapsulates all CLI option definitions for the run command."""
 
+    CONFIG = typer.Option(
+        None,
+        "--config",
+        help="Path to config file that overrides user/workspace config.",
+    )
+    API = typer.Option(
+        False,
+        "--api",
+        help="Machine-readable API contract output (JSON by default).",
+    )
+    PROMPT_DIR = typer.Option(
+        None,
+        "--prompt-dir",
+        help="Override the prompt catalog directory for this invocation.",
+    )
     PROMPT = typer.Option(..., "--prompt", help="Prompt key to execute.")
     INPUT_FILE = typer.Option(..., "--input-file", help="Input file containing user content.")
     VARS_FILE = typer.Option(None, "--vars", help="JSON file with variable definitions.")
@@ -70,6 +95,7 @@ class RunContext:
     config_meta: ConfigMeta
     service: GenAIServiceProtocol
     metadata: PromptMetadata
+    input_metadata: Metadata
     variables: VariableMap
     trace_id: str
     model_override: str | None
@@ -80,24 +106,6 @@ class RunContext:
 
 
 # ---- Variable Handling ----
-
-
-def _read_input_text(path: Path) -> str:
-    """Read input text file with error handling.
-
-    Args:
-        path: Path to the user-provided input text file.
-
-    Returns:
-        Contents of the input file decoded as UTF-8.
-
-    Raises:
-        ValueError: If the file cannot be read.
-    """
-    try:
-        return path.read_text(encoding="utf-8")
-    except Exception as exc:
-        raise ValueError(f"Unable to read input file {path}") from exc
 
 
 def _load_vars_file(path: Path | None) -> VariableMap:
@@ -138,8 +146,20 @@ def _parse_inline_vars(inline_vars: list[str]) -> VariableMap:
     return variables
 
 
+def _read_input_document(input_file: Path) -> tuple[Metadata, str]:
+    """Read input document frontmatter and body text.
+
+    Raises:
+        ValueError: If the input file cannot be read.
+    """
+    try:
+        return Frontmatter.extract_from_file(input_file)
+    except Exception as exc:
+        raise ValueError(f"Unable to read input file {input_file}") from exc
+
+
 def _merge_variables(
-    input_file: Path,
+    input_text: str,
     vars_file: Path | None,
     inline_vars: list[str],
     defaults: VariableMap,
@@ -147,7 +167,7 @@ def _merge_variables(
     """Merge variables with correct precedence: defaults → input → vars file → inline.
 
     Args:
-        input_file: Path to the primary input text file.
+        input_text: Body text extracted from the primary input document.
         vars_file: Optional JSON file containing variable overrides.
         inline_vars: Inline `--var` assignments.
         defaults: Prompt-provided default variables.
@@ -156,7 +176,7 @@ def _merge_variables(
         Combined variable dictionary ready for rendering.
     """
     merged: VariableMap = dict(defaults)
-    merged["input_text"] = _read_input_text(input_file)
+    merged["input_text"] = input_text
     merged |= _load_vars_file(vars_file)
     merged.update(_parse_inline_vars(inline_vars))
     return _normalize_variable_keys(merged)
@@ -231,6 +251,7 @@ def _prepare_run_context(
     output_format: OutputFormat | None,
     no_provenance: bool,
     trace_id: str,
+    prompt_dir: Path | None = None,
 ) -> RunContext:
     """Prepare all context needed for prompt execution.
 
@@ -239,6 +260,7 @@ def _prepare_run_context(
         input_file: Path to user input text.
         vars_file: Optional path to JSON variables file.
         inline_vars: Inline variable assignments from CLI.
+        prompt_dir: Optional prompt catalog directory override.
         model: Optional model override.
         intent: Optional routing intent.
         max_tokens: Optional max output tokens override.
@@ -257,7 +279,7 @@ def _prepare_run_context(
     """
     # Load configuration
     overrides: ConfigData = {"default_model": model}
-    config, meta = load_config(ctx.config_path, overrides=overrides)
+    config, meta = load_config(ctx.config_path, overrides=overrides, prompt_dir=prompt_dir)
 
     # Get service factory from context
     factory = ctx.service_factory
@@ -269,10 +291,14 @@ def _prepare_run_context(
 
     # Get prompt metadata
     metadata = _ensure_input_text_variable(service.catalog.introspect(prompt_key))
+    input_metadata, input_text = _read_input_document(input_file)
 
     # Merge variables with correct precedence
     variables = _merge_variables(
-        input_file, vars_file, inline_vars, defaults=metadata.default_variables
+        input_text,
+        vars_file,
+        inline_vars,
+        defaults=metadata.default_variables,
     )
 
     # Validate required variables
@@ -284,6 +310,7 @@ def _prepare_run_context(
         config_meta=meta,
         service=service,
         metadata=metadata,
+        input_metadata=input_metadata,
         variables=variables,
         trace_id=trace_id,
         model_override=model,
@@ -294,13 +321,73 @@ def _prepare_run_context(
     )
 
 
+def _result_payload_from_envelope(envelope: CompletionEnvelope) -> RunResultPayload | None:
+    """Build the result payload when a completion result is present."""
+    result = envelope.result
+    if result is None:
+        return None
+
+    usage_payload: RunUsagePayload | None = None
+    if result.usage:
+        usage_payload = {
+            "prompt_tokens": result.usage.prompt_tokens,
+            "completion_tokens": result.usage.completion_tokens,
+            "total_tokens": result.usage.total_tokens,
+        }
+
+    return {
+        "text": result.text,
+        "model": result.model,
+        "provider": result.provider,
+        "usage": usage_payload,
+        "finish_reason": result.finish_reason,
+    }
+
+
+def _provenance_payload(
+    envelope: CompletionEnvelope,
+    metadata: PromptMetadata,
+) -> RunProvenancePayload:
+    """Build the provenance payload for API serialization."""
+    return {
+        "backend": envelope.provenance.provider,
+        "model": envelope.provenance.model,
+        "prompt_key": envelope.provenance.fingerprint.prompt_key,
+        "prompt_fingerprint": envelope.provenance.fingerprint.prompt_content_hash,
+        "prompt_version": metadata.version,
+        "started_at": envelope.provenance.started_at.isoformat(),
+        "completed_at": envelope.provenance.finished_at.isoformat(),
+        "schema_version": envelope.provenance.fingerprint.schema_version,
+    }
+
+
+def _failure_payload(failure: CompletionFailure) -> RunFailurePayload:
+    """Convert a typed completion failure into an API payload."""
+    diagnostics = failure.adapter_diagnostics
+    adapter_diagnostics: RunAdapterDiagnosticsPayload | None = None
+    if diagnostics is not None:
+        adapter_diagnostics = {
+            "content_source": diagnostics.content_source,
+            "content_part_count": diagnostics.content_part_count,
+            "raw_finish_reason": diagnostics.raw_finish_reason,
+            "extraction_notes": diagnostics.extraction_notes,
+        }
+
+    return {
+        "reason": failure.reason.value,
+        "message": failure.message,
+        "retryable": failure.retryable,
+        "adapter_diagnostics": adapter_diagnostics,
+    }
+
+
 def _build_success_payload(
     envelope: CompletionEnvelope,
     metadata: PromptMetadata,
     config_meta: ConfigMeta,
     trace_id: str,
-) -> RunSuccessPayload:
-    """Build success response payload for CLI output serialization.
+) -> RunOutcomePayload:
+    """Build run response payload for CLI output serialization.
 
     This is the canonical place where the CLI output payload is constructed.
     Returns an untyped dict intended exclusively for direct output stream
@@ -322,47 +409,48 @@ def _build_success_payload(
     Returns:
         Untyped payload suitable for serialization to stdout.
     """
-    result = envelope.result
-    usage = result.usage if result else None
-
-    usage_payload: RunUsagePayload | None = None
-    if usage:
-        usage_payload = {
-            "prompt_tokens": usage.prompt_tokens,
-            "completion_tokens": usage.completion_tokens,
-            "total_tokens": usage.total_tokens,
-        }
-
-    result_payload: RunResultPayload = {
-        "text": result.text if result else "",
-        "model": result.model if result else None,
-        "provider": result.provider if result else None,
-        "usage": usage_payload,
-        "finish_reason": result.finish_reason if result else None,
-    }
-    provenance_payload: RunProvenancePayload = {
-        "backend": envelope.provenance.provider,
-        "model": envelope.provenance.model,
-        "prompt_key": envelope.provenance.fingerprint.prompt_key,
-        "prompt_fingerprint": envelope.provenance.fingerprint.prompt_content_hash,
-        "prompt_version": metadata.version,
-        "started_at": envelope.provenance.started_at.isoformat(),
-        "completed_at": envelope.provenance.finished_at.isoformat(),
-        "schema_version": envelope.provenance.fingerprint.schema_version,
-    }
-    policy_applied: PolicyApplied = envelope.policy_applied or {}
+    result_payload = _result_payload_from_envelope(envelope)
+    provenance_payload = _provenance_payload(envelope, metadata)
+    policy_applied: PolicyApplied = dict(envelope.policy_applied or {})
     prompt_warnings = list(getattr(metadata, "warnings", []) or [])
+    warnings = list(envelope.warnings or [])
+    sources = list(config_meta["sources"])
 
-    return {
-        "status": "succeeded",
-        "result": result_payload,
+    base_payload = {
         "provenance": provenance_payload,
-        "warnings": envelope.warnings,
+        "warnings": warnings,
         "prompt_warnings": prompt_warnings,
         "policy_applied": policy_applied,
-        "sources": config_meta["sources"],
+        "sources": sources,
         "trace_id": trace_id,
     }
+
+    match envelope.outcome:
+        case CompletionOutcomeStatus.SUCCEEDED:
+            if result_payload is None:
+                raise ValueError("succeeded envelopes require result")
+            return {
+                **base_payload,
+                "status": "succeeded",
+                "result": result_payload,
+            }
+        case CompletionOutcomeStatus.INCOMPLETE:
+            if result_payload is None:
+                raise ValueError("incomplete envelopes require result")
+            return {
+                **base_payload,
+                "status": "incomplete",
+                "result": result_payload,
+            }
+        case CompletionOutcomeStatus.FAILED:
+            if envelope.failure is None:
+                raise ValueError("failed envelopes require failure")
+            return {
+                **base_payload,
+                "status": "failed",
+                "failure": _failure_payload(envelope.failure),
+            }
+    raise ValueError(f"Unsupported completion outcome: {envelope.outcome}")
 
 
 # ---- Output Handling ----
@@ -370,19 +458,35 @@ def _build_success_payload(
 
 def _emit_warnings(
     envelope: CompletionEnvelope,
-    metadata: PromptMetadata,
-    quiet: bool,
+    metadata: PromptMetadata | None = None,
+    quiet: bool = False,
+    api: bool = False,
 ) -> None:
-    if quiet:
+    if quiet or api:
         return
     for warning in envelope.warnings or []:
         typer.echo(f"[warn] {warning}", err=True)
-    for warning in getattr(metadata, "warnings", []) or []:
-        typer.echo(f"[warn] {warning}", err=True)
+
+
+def _emit_catalog_health_summary(context: RunContext, api: bool) -> None:
+    """Emit a single fatal catalog-health summary in human mode."""
+    if api or ctx.quiet:
+        return
+    health_getter = getattr(context.service.catalog, "catalog_health", None)
+    if not callable(health_getter):
+        return
+    catalog_health = health_getter()
+    if catalog_health.error_count == 0:
+        return
+    typer.echo(
+        f"[tnh-gen] {catalog_health.error_count} prompts failed to load. "
+        "Run 'tnh-gen config show --catalog-health' for details.",
+        err=True,
+    )
 
 
 def _emit_stdout(
-    payload: RunSuccessPayload,
+    payload: RunOutcomePayload,
     result_text: str,
     output_format: OutputFormat | None,
     api: bool,
@@ -398,28 +502,111 @@ def _emit_stdout(
     typer.echo(result_text)
 
 
+def _emit_completion_failure(
+    trace_id: str,
+    envelope: CompletionEnvelope,
+    payload: RunOutcomePayload,
+    output_format: OutputFormat | None,
+    api: bool,
+) -> None:
+    if api:
+        fmt = resolve_output_format(
+            api=True,
+            format_override=output_format,
+            default_format=OutputFormat.json,
+        )
+        typer.echo(render_output(payload, fmt))
+        return
+
+    failure_message = envelope.failure.message if envelope.failure else "Completion failed."
+    error_code = (
+        envelope.failure.reason.value.upper()
+        if envelope.failure is not None
+        else "COMPLETION_FAILED"
+    )
+    emit_trace_id(trace_id, error_code)
+    typer.echo(format_human_friendly_error(RuntimeError(failure_message)))
+
+
+def _budget_block_details(exc: SafetyBlocked) -> tuple[float, float] | None:
+    """Extract structured budget-block details when present."""
+    if exc.blocked_reason != "budget":
+        return None
+    if exc.estimated_cost is None or exc.max_dollars is None:
+        return None
+    return exc.estimated_cost, exc.max_dollars
+
+
+def _emit_budget_block(
+    trace_id: str,
+    estimated_cost: float,
+    max_dollars: float,
+    output_format: OutputFormat | None,
+    api: bool,
+) -> None:
+    """Render a budget-block response with actionable guidance."""
+    if api:
+        payload = {
+            "status": "blocked",
+            "blocked_reason": "budget",
+            "estimated_cost": estimated_cost,
+            "max_dollars": max_dollars,
+            "trace_id": trace_id,
+        }
+        fmt = resolve_output_format(
+            api=True,
+            format_override=output_format,
+            default_format=OutputFormat.json,
+        )
+        typer.echo(render_output(payload, fmt))
+        return
+
+    emit_trace_id(trace_id, "SAFETY_BUDGET_BLOCKED")
+    error = RuntimeError(
+        f"Budget blocked: estimated cost ${estimated_cost:.4f} exceeds budget ${max_dollars:.4f}."
+    )
+    suggestion = (
+        "Raise max_dollars in config, for example:\n"
+        "  tnh-gen config set --workspace max_dollars 0.10"
+    )
+    typer.echo(format_human_friendly_error(error, suggestion=suggestion))
+
+
 def _emit_run_output(
     context: RunContext,
     envelope: CompletionEnvelope,
-    payload: RunSuccessPayload,
+    payload: RunOutcomePayload,
     api: bool,
 ) -> None:
-    _emit_warnings(envelope, context.metadata, ctx.quiet)
+    _emit_warnings(envelope, context.metadata, ctx.quiet, api)
+    _emit_catalog_health_summary(context, api)
+    if envelope.outcome is CompletionOutcomeStatus.FAILED:
+        _emit_completion_failure(
+            context.trace_id,
+            envelope,
+            payload,
+            context.output_format,
+            api,
+        )
+        raise typer.Exit(code=int(ExitCode.PROVIDER_ERROR))
+
     result_text = envelope.result.text if envelope.result else ""
     if context.output_file:
         write_output_file(
             context.output_file,
             result_text=result_text,
             envelope=envelope,
+            source_metadata=context.input_metadata,
             trace_id=context.trace_id,
             prompt_version=context.metadata.version,
             include_provenance=context.include_provenance,
         )
-        typer.echo(f"Wrote output to {context.output_file}", err=True)
+        if not api:
+            typer.echo(f"Wrote output to {context.output_file}", err=True)
     _emit_stdout(payload, result_text, context.output_format, api)
 
 
-def _execute_prompt(context: RunContext) -> tuple[CompletionEnvelope, RunSuccessPayload]:
+def _execute_prompt(context: RunContext) -> tuple[CompletionEnvelope, RunOutcomePayload]:
     """Execute the prompt for the given context and build the success payload."""
     user_input = str(context.variables.get("input_text", ""))
     request = RenderRequest(
@@ -482,6 +669,9 @@ def _handle_error(exc: Exception, trace_id: str, format_override: OutputFormat |
 
 @app.callback()
 def run_prompt(
+    config: Path | None = TnhGenCLIOptions.CONFIG,
+    api: bool = TnhGenCLIOptions.API,
+    prompt_dir: Path | None = TnhGenCLIOptions.PROMPT_DIR,
     prompt: str = TnhGenCLIOptions.PROMPT,
     input_file: Path = TnhGenCLIOptions.INPUT_FILE,
     vars_file: Path | None = TnhGenCLIOptions.VARS_FILE,
@@ -499,6 +689,9 @@ def run_prompt(
     """Execute a prompt with variable substitution and AI processing.
 
     Args:
+        config: Optional path to an explicit config file.
+        api: Whether to emit machine-readable API contract output.
+        prompt_dir: Optional prompt catalog directory override.
         prompt: Key of the prompt to execute.
         input_file: File containing the main user input text.
         vars_file: Optional JSON file with additional variables.
@@ -516,6 +709,11 @@ def run_prompt(
     trace_id = uuid4().hex
 
     try:
+        if config is not None:
+            ctx.config_path = config
+        if api:
+            ctx.api = True
+
         _validate_run_options(streaming, top_p)
         _apply_api_settings(format)
 
@@ -525,6 +723,7 @@ def run_prompt(
             input_file=input_file,
             vars_file=vars_file,
             inline_vars=var,
+            prompt_dir=prompt_dir,
             model=model,
             intent=intent,
             max_tokens=max_tokens,
@@ -540,5 +739,15 @@ def run_prompt(
 
         _emit_run_output(context, envelope, payload, ctx.api)
 
+    except SafetyBlocked as exc:
+        budget_details = _budget_block_details(exc)
+        if budget_details is None:
+            _handle_error(exc, trace_id, format)
+            return
+        estimated_cost, max_dollars = budget_details
+        _emit_budget_block(trace_id, estimated_cost, max_dollars, format, ctx.api)
+        raise typer.Exit(code=int(ExitCode.POLICY_ERROR))
+    except typer.Exit:
+        raise
     except Exception as exc:
         _handle_error(exc, trace_id, format)

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
@@ -100,6 +100,7 @@ class RunContext:
     trace_id: str
     model_override: str | None
     intent: str | None
+    quiet: bool
     output_format: OutputFormat | None
     output_file: Path | None
     include_provenance: bool
@@ -315,6 +316,7 @@ def _prepare_run_context(
         trace_id=trace_id,
         model_override=model,
         intent=intent,
+        quiet=ctx.quiet,
         output_format=output_format or ctx.output_format,
         output_file=output_file,
         include_provenance=not no_provenance,
@@ -470,7 +472,7 @@ def _emit_warnings(
 
 def _emit_catalog_health_summary(context: RunContext, api: bool) -> None:
     """Emit a single fatal catalog-health summary in human mode."""
-    if api or ctx.quiet:
+    if api or context.quiet:
         return
     health_getter = getattr(context.service.catalog, "catalog_health", None)
     if not callable(health_getter):

--- a/src/tnh_scholar/cli_tools/tnh_gen/config_loader.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/config_loader.py
@@ -104,17 +104,20 @@ def load_config(
     *,
     cwd: Path | None = None,
     overrides: ConfigData | None = None,
+    prompt_dir: Path | None = None,
 ) -> tuple[CLIConfig, ConfigMeta]:
     """Load CLI configuration with clear precedence and metadata.
 
     The effective config is built in this order: defaults/env → user config →
-    workspace config → explicit config_path → CLI overrides. Overrides that are
-    `None` are ignored to avoid clobbering previous values.
+    workspace config → explicit config_path → CLI overrides → explicit
+    prompt_dir override. Overrides that are `None` are ignored to avoid
+    clobbering previous values.
 
     Args:
         config_path: Optional explicit config file to load.
         cwd: Working directory for resolving workspace config paths.
         overrides: In-memory override values (e.g., CLI flags).
+        prompt_dir: Optional prompt catalog directory override.
 
     Returns:
         Tuple of validated `CLIConfig` and metadata containing the source list.
@@ -159,6 +162,10 @@ def load_config(
             if key in base and value is not None:
                 base[key] = value
         sources.append("cli-overrides")
+
+    if prompt_dir is not None:
+        base["prompt_catalog_dir"] = prompt_dir
+        sources.append("cli-prompt-dir")
 
     meta: ConfigMeta = {"sources": sources, "config_files": config_files}
     return CLIConfig.model_validate(base), meta

--- a/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
-from tnh_scholar.gen_ai_service.models.domain import CompletionEnvelope
+from tnh_scholar.gen_ai_service.models.domain import CompletionEnvelope, CompletionOutcomeStatus
+from tnh_scholar.metadata import Frontmatter, Metadata
 
 
 def _iso(dt: datetime) -> str:
@@ -21,26 +22,29 @@ def _iso(dt: datetime) -> str:
 def provenance_block(
     envelope: CompletionEnvelope,
     *,
+    source_metadata: Metadata | None = None,
     trace_id: str,
     prompt_version: str | None,
 ) -> str:
     """Build a YAML frontmatter block capturing provenance for saved files."""
     fp = envelope.provenance.fingerprint
     version = prompt_version or "unknown"
-    lines = [
-        "---",
-        "tnh_scholar_generated: true",
-        f"prompt_key: {fp.prompt_key}",
-        f"prompt_version: \"{version}\"",
-        f"model: {envelope.provenance.model}",
-        f"fingerprint: {fp.prompt_content_hash}",
-        f"trace_id: {trace_id}",
-        f"generated_at: \"{_iso(envelope.provenance.finished_at)}\"",
-        "schema_version: \"1.0\"",
-        "---",
-        "",
-    ]
-    return "\n".join(lines)
+    provenance_metadata = Metadata(
+        {
+            "tnh_scholar_generated": True,
+            "prompt_key": fp.prompt_key,
+            "prompt_version": version,
+            "model": envelope.provenance.model,
+            "fingerprint": fp.prompt_content_hash,
+            "trace_id": trace_id,
+            "generated_at": _iso(envelope.provenance.finished_at),
+            "schema_version": "1.0",
+        }
+    )
+    merged_metadata = provenance_metadata
+    if source_metadata:
+        merged_metadata = source_metadata | provenance_metadata
+    return Frontmatter.generate(merged_metadata)
 
 
 def write_output_file(
@@ -48,18 +52,24 @@ def write_output_file(
     *,
     result_text: str,
     envelope: CompletionEnvelope,
+    source_metadata: Metadata | None = None,
     trace_id: str,
     prompt_version: str | None,
     include_provenance: bool,
 ) -> None:
     """Write result text to disk, optionally prefixing provenance metadata."""
+    if envelope.outcome is CompletionOutcomeStatus.FAILED:
+        raise ValueError("Cannot write output for a failed completion outcome")
     path.parent.mkdir(parents=True, exist_ok=True)
     if include_provenance:
         header = provenance_block(
             envelope,
+            source_metadata=source_metadata,
             trace_id=trace_id,
             prompt_version=prompt_version,
         )
         path.write_text(f"{header}{result_text}", encoding="utf-8")
+    elif source_metadata:
+        path.write_text(f"{Frontmatter.generate(source_metadata)}{result_text}", encoding="utf-8")
     else:
         path.write_text(result_text, encoding="utf-8")

--- a/src/tnh_scholar/cli_tools/tnh_gen/tnh_gen.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/tnh_gen.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
@@ -22,12 +24,36 @@ app = typer.Typer(
 )
 
 
+@contextmanager
+def _override_prompt_dir_env(prompt_dir: Path | None):
+    """Temporarily override `TNH_PROMPT_DIR` for the current CLI invocation."""
+    if prompt_dir is None:
+        yield
+        return
+
+    original_prompt_dir = os.environ.get("TNH_PROMPT_DIR")
+    os.environ["TNH_PROMPT_DIR"] = str(prompt_dir)
+    try:
+        yield
+    finally:
+        if original_prompt_dir is None:
+            os.environ.pop("TNH_PROMPT_DIR", None)
+        else:
+            os.environ["TNH_PROMPT_DIR"] = original_prompt_dir
+
+
 @app.callback()
 def cli_callback(
+    click_ctx: typer.Context,
     config: Optional[Path] = typer.Option(
         None,
         "--config",
         help="Path to config file that overrides user/workspace config.",
+    ),
+    prompt_dir: Path | None = typer.Option(
+        None,
+        "--prompt-dir",
+        help="Override the prompt catalog directory for this invocation.",
     ),
     format: OutputFormat | None = typer.Option(
         None,
@@ -51,11 +77,13 @@ def cli_callback(
     Examples:
       tnh-gen list
       tnh-gen --api list
+      tnh-gen --prompt-dir ./prompts list
       tnh-gen run --prompt daily --input-file notes.md
       tnh-gen --api run --prompt daily --input-file notes.md
 
     Args:
         config: Optional path to an explicit config file.
+        prompt_dir: Optional prompt catalog directory override.
         format: Output format override for commands.
         api: Whether to emit machine-readable API contract output.
         quiet: Whether to suppress non-error output.
@@ -66,6 +94,10 @@ def cli_callback(
     # Load environment variables from a .env file so settings (e.g., API keys)
     # are available before config and service initialization.
     load_dotenv(dotenv_path=find_dotenv(usecwd=True) or None)
+
+    prompt_dir_scope = _override_prompt_dir_env(prompt_dir)
+    prompt_dir_scope.__enter__()
+    click_ctx.call_on_close(lambda: prompt_dir_scope.__exit__(None, None, None))
 
     ctx.config_path = config
     ctx.output_format = format

--- a/src/tnh_scholar/cli_tools/tnh_gen/types.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/types.py
@@ -148,15 +148,45 @@ class RunProvenancePayload(TypedDict):
     schema_version: str
 
 
-class RunSuccessPayload(TypedDict):
-    status: str
-    result: RunResultPayload
+class RunAdapterDiagnosticsPayload(TypedDict):
+    content_source: str
+    content_part_count: int | None
+    raw_finish_reason: str | None
+    extraction_notes: str | None
+
+
+class RunFailurePayload(TypedDict):
+    reason: str
+    message: str
+    retryable: bool
+    adapter_diagnostics: RunAdapterDiagnosticsPayload | None
+
+
+class RunBasePayload(TypedDict):
     provenance: RunProvenancePayload
-    warnings: list[str] | None
+    warnings: list[str]
     prompt_warnings: list[str]
     policy_applied: PolicyApplied
     sources: list[str]
     trace_id: str
+
+
+class RunSuccessPayload(RunBasePayload):
+    status: Literal["succeeded"]
+    result: RunResultPayload
+
+
+class RunIncompletePayload(RunBasePayload):
+    status: Literal["incomplete"]
+    result: RunResultPayload
+
+
+class RunFailedPayload(RunBasePayload):
+    status: Literal["failed"]
+    failure: RunFailurePayload
+
+
+RunOutcomePayload = RunSuccessPayload | RunIncompletePayload | RunFailedPayload
 
 
 class VersionPayload(TypedDict):

--- a/src/tnh_scholar/gen_ai_service/mappers/completion_mapper.py
+++ b/src/tnh_scholar/gen_ai_service/mappers/completion_mapper.py
@@ -1,24 +1,105 @@
 # mappers/completion_mapper.py
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
-from tnh_scholar.gen_ai_service.models.domain import CompletionEnvelope, CompletionResult, Provenance, Usage
-from tnh_scholar.gen_ai_service.models.transport import (
-    ErrorInfo,
-    ProviderResponse,
-    ProviderStatus,
-    TextPayload,
+from tnh_scholar.gen_ai_service.models.domain import (
+    CompletionEnvelope,
+    CompletionFailure,
+    CompletionOutcomeStatus,
+    CompletionResult,
+    FailureReason,
+    Provenance,
+    Usage,
 )
+from tnh_scholar.gen_ai_service.models.transport import ErrorInfo, ProviderResponse, ProviderStatus, TextPayload
 
 PolicyApplied = Dict[str, Union[str, int, float]]
 
 
-def _usage_from_provider(usage) -> Optional[Usage]:
+def _usage_from_provider(usage: Any) -> Optional[Usage]:
     if usage is None:
         return None
     return Usage(
         prompt_tokens=usage.tokens_in or 0,
         completion_tokens=usage.tokens_out or 0,
         total_tokens=usage.tokens_total or 0,
+    )
+
+
+def _outcome_from_response(
+    resp: ProviderResponse,
+    payload: TextPayload | None,
+) -> CompletionOutcomeStatus:
+    match resp.status:
+        case ProviderStatus.OK:
+            return (
+                CompletionOutcomeStatus.SUCCEEDED
+                if payload is not None
+                else CompletionOutcomeStatus.FAILED
+            )
+        case ProviderStatus.INCOMPLETE:
+            return (
+                CompletionOutcomeStatus.INCOMPLETE
+                if payload is not None
+                else CompletionOutcomeStatus.FAILED
+            )
+        case ProviderStatus.FAILED | ProviderStatus.FILTERED | ProviderStatus.RATE_LIMITED:
+            return CompletionOutcomeStatus.FAILED
+    return CompletionOutcomeStatus.FAILED
+
+
+def _retryable_for_failure(reason: FailureReason) -> bool:
+    match reason:
+        case FailureReason.EMPTY_CONTENT_WITH_TOKENS:
+            return False
+        case FailureReason.CONTENT_FIELD_MISSING:
+            return False
+        case FailureReason.UNSUPPORTED_RESPONSE_SHAPE:
+            return False
+        case FailureReason.CONTENT_EXTRACTION_ERROR:
+            return False
+    return False
+
+
+def _failure_message(resp: ProviderResponse, reason: FailureReason) -> str:
+    if resp.error is not None and resp.error.message:
+        return resp.error.message
+
+    match reason:
+        case FailureReason.EMPTY_CONTENT_WITH_TOKENS:
+            return "Provider returned no extractable text after consuming completion tokens."
+        case FailureReason.CONTENT_FIELD_MISSING:
+            return "Provider response did not include extractable content."
+        case FailureReason.UNSUPPORTED_RESPONSE_SHAPE:
+            return "Provider response shape was not recognized by the adapter."
+        case FailureReason.CONTENT_EXTRACTION_ERROR:
+            return "Adapter failed while extracting content from the provider response."
+    return "Provider response could not be converted into a completion result."
+
+
+def _default_failure_reason(resp: ProviderResponse) -> FailureReason:
+    if resp.error is not None:
+        return FailureReason.CONTENT_EXTRACTION_ERROR
+    if resp.incomplete_reason:
+        return FailureReason.CONTENT_FIELD_MISSING
+    return FailureReason.UNSUPPORTED_RESPONSE_SHAPE
+
+
+def _failure_from_response(
+    resp: ProviderResponse,
+    outcome: CompletionOutcomeStatus,
+) -> CompletionFailure | None:
+    if outcome is not CompletionOutcomeStatus.FAILED:
+        return None
+
+    reason = resp.failure_reason
+    if reason is None:
+        reason = _default_failure_reason(resp)
+
+    return CompletionFailure(
+        reason=reason,
+        message=_failure_message(resp, reason),
+        retryable=_retryable_for_failure(reason),
+        adapter_diagnostics=resp.adapter_diagnostics,
     )
 
 
@@ -31,6 +112,36 @@ def _policy_from_error(error: ErrorInfo | None) -> Dict[str, str]:
         "provider_error_code": error.code or "",
         "provider_error_message": message,
     }
+
+
+def _build_warnings_and_policy(
+    resp: ProviderResponse,
+    outcome: CompletionOutcomeStatus,
+    warnings: Optional[List[str]],
+    policy_applied: Optional[PolicyApplied],
+    payload: TextPayload | None,
+) -> tuple[list[str], PolicyApplied]:
+    warnings_out = list(warnings) if warnings else []
+    policy_out: PolicyApplied = dict(policy_applied) if policy_applied else {}
+
+    if outcome is CompletionOutcomeStatus.FAILED:
+        warnings_out.append(f"provider-status:{resp.status}")
+        if resp.incomplete_reason:
+            warnings_out.append(f"incomplete:{resp.incomplete_reason}")
+        if payload is None:
+            warnings_out.append("provider-missing-payload")
+        policy_out.update(_policy_from_error(resp.error))
+        return warnings_out, policy_out
+
+    if payload is None:
+        warnings_out.append("provider-missing-payload")
+
+    if resp.status != ProviderStatus.OK:
+        warnings_out.append(f"provider-status:{resp.status}")
+        if resp.incomplete_reason:
+            warnings_out.append(f"incomplete:{resp.incomplete_reason}")
+        policy_out.update(_policy_from_error(resp.error))
+    return warnings_out, policy_out
 
 
 def provider_to_completion(
@@ -52,15 +163,19 @@ def provider_to_completion(
     Returns:
         CompletionEnvelope with result (if available), provenance, policy diagnostics, and warnings.
     """
-    warnings_out: list[str] = list(warnings) if warnings else []
-    policy_out: PolicyApplied = dict(policy_applied) if policy_applied else {}
-
     result: CompletionResult | None = None
     payload = resp.payload if isinstance(resp.payload, TextPayload) else None
+    outcome = _outcome_from_response(resp, payload)
+    failure = _failure_from_response(resp, outcome)
+    warnings_out, policy_out = _build_warnings_and_policy(
+        resp,
+        outcome,
+        warnings,
+        policy_applied,
+        payload,
+    )
 
-    if payload is None:
-        warnings_out.append("provider-missing-payload")
-    else:
+    if payload is not None and outcome is not CompletionOutcomeStatus.FAILED:
         result = CompletionResult(
             text=payload.text,
             usage=_usage_from_provider(resp.usage),
@@ -70,14 +185,10 @@ def provider_to_completion(
             finish_reason=payload.finish_reason,
         )
 
-    if resp.status != ProviderStatus.OK:
-        warnings_out.append(f"provider-status:{resp.status}")
-        if resp.incomplete_reason:
-            warnings_out.append(f"incomplete:{resp.incomplete_reason}")
-        policy_out.update(_policy_from_error(resp.error))
-
     return CompletionEnvelope(
+        outcome=outcome,
         result=result,
+        failure=failure,
         provenance=provenance,
         policy_applied=policy_out,
         warnings=warnings_out,

--- a/src/tnh_scholar/gen_ai_service/models/domain.py
+++ b/src/tnh_scholar/gen_ai_service/models/domain.py
@@ -39,7 +39,7 @@ from typing import Any, List, Literal, Mapping, Optional, Union
 from openai.types.chat.chat_completion_content_part_param import (
     ChatCompletionContentPartParam,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # TODO: Consolidate RenderVars into a shared GenAI types module to avoid duplication.
 # V1 Requirement (ADR-A02) to avoid passing raw dicts
@@ -82,6 +82,26 @@ class Usage(BaseModel):
     total_tokens: int
 
 
+class CompletionOutcomeStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    INCOMPLETE = "incomplete"
+    FAILED = "failed"
+
+
+class FailureReason(str, Enum):
+    EMPTY_CONTENT_WITH_TOKENS = "empty_content_with_tokens"
+    CONTENT_FIELD_MISSING = "content_field_missing"
+    UNSUPPORTED_RESPONSE_SHAPE = "unsupported_response_shape"
+    CONTENT_EXTRACTION_ERROR = "content_extraction_error"
+
+
+class AdapterDiagnostics(BaseModel):
+    content_source: str
+    content_part_count: int | None = None
+    raw_finish_reason: str | None = None
+    extraction_notes: str | None = None
+
+
 class CompletionResult(BaseModel):
     text: str
     usage: Usage | None
@@ -101,11 +121,39 @@ class Provenance(BaseModel):
     fingerprint: Fingerprint
 
 
+class CompletionFailure(BaseModel):
+    reason: FailureReason
+    message: str
+    retryable: bool = False
+    adapter_diagnostics: AdapterDiagnostics | None = None
+
+
 class CompletionEnvelope(BaseModel):
+    outcome: CompletionOutcomeStatus
     result: CompletionResult | None = None
+    failure: CompletionFailure | None = None
     provenance: Provenance
-    policy_applied: dict
+    policy_applied: dict[str, Any] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_outcome(self) -> "CompletionEnvelope":
+        if self.outcome is CompletionOutcomeStatus.SUCCEEDED:
+            if self.result is None:
+                raise ValueError("succeeded envelopes require result")
+            if self.failure is not None:
+                raise ValueError("succeeded envelopes cannot include failure")
+        elif self.outcome is CompletionOutcomeStatus.INCOMPLETE:
+            if self.result is None:
+                raise ValueError("incomplete envelopes require result")
+            if self.failure is not None:
+                raise ValueError("incomplete envelopes cannot include failure")
+        elif self.outcome is CompletionOutcomeStatus.FAILED:
+            if self.result is not None:
+                raise ValueError("failed envelopes cannot include result")
+            if self.failure is None:
+                raise ValueError("failed envelopes require failure")
+        return self
 
 
 class Role(str, Enum):

--- a/src/tnh_scholar/gen_ai_service/models/errors.py
+++ b/src/tnh_scholar/gen_ai_service/models/errors.py
@@ -10,6 +10,8 @@ Connected modules:
   - safety.safety_gate
 """
 
+from typing import Literal
+
 from tnh_scholar.exceptions import TnhScholarError
 
 
@@ -19,6 +21,19 @@ class PatternNotFound(TnhScholarError):
 
 class SafetyBlocked(TnhScholarError):
     """Raised when content fails safety validation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        blocked_reason: Literal["budget"] | None = None,
+        estimated_cost: float | None = None,
+        max_dollars: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.blocked_reason = blocked_reason
+        self.estimated_cost = estimated_cost
+        self.max_dollars = max_dollars
 
 
 class RoutingError(TnhScholarError):

--- a/src/tnh_scholar/gen_ai_service/models/transport.py
+++ b/src/tnh_scholar/gen_ai_service/models/transport.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel
 
-from .domain import Message
+from .domain import AdapterDiagnostics, FailureReason, Message
 
 
 class ProviderName(str):
@@ -32,12 +32,14 @@ class ProviderRequest(BaseModel):
     seed: Optional[int] = None
     response_format: Optional[Type[BaseModel]] = None
 
+
 class ProviderStatus(str, Enum):
     OK = "ok"
     INCOMPLETE = "incomplete"
     FAILED = "failed"
     FILTERED = "filtered"
     RATE_LIMITED = "rate_limited"
+
 
 class FinishReason(str, Enum):
     STOP = "stop"
@@ -61,6 +63,7 @@ class ErrorInfo(BaseModel):
     code: Optional[str] = None
     retry_after_s: Optional[float] = None
 
+
 class ProviderUsage(BaseModel):
     """Transport-level usage (provider-agnostic, not domain)."""
     tokens_in: Optional[int] = None          # aka prompt/input tokens
@@ -79,6 +82,7 @@ class TextPayload(BaseModel):
     finish_reason: Optional[FinishReason] = None
     parsed: Optional[BaseModel] = None
 
+
 class ProviderResponse(BaseModel):
     """Normalized provider response.
 
@@ -95,5 +99,6 @@ class ProviderResponse(BaseModel):
     payload: Optional[TextPayload] = None
     usage: Optional[ProviderUsage] = None
     error: Optional[ErrorInfo] = None
+    failure_reason: Optional[FailureReason] = None
+    adapter_diagnostics: Optional[AdapterDiagnostics] = None
     incomplete_reason: Optional[str] = None
-    

--- a/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
@@ -26,6 +26,7 @@ TODOs for Hardening:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, cast
 
 from openai.types.chat.chat_completion import ChatCompletion
@@ -57,6 +58,15 @@ class OpenAIChatCompletionRequest(BaseModel):
     max_completion_tokens: int
     seed: Optional[int] = None
     response_format: Optional[type[BaseModel]] = None
+
+
+@dataclass(frozen=True)
+class ContentExtractionResult:
+    payload: TextPayload | None
+    failure_reason: FailureReason | None
+    extraction_notes: str | None
+    content_part_count: int | None
+    raw_finish_reason: str | None
 
 
 def _finish_reason_from_raw(raw_finish_reason: Any) -> FinishReason:
@@ -181,9 +191,9 @@ def _usage_from_openai_response(response: ChatCompletion) -> tuple[ProviderStatu
     if usage_obj is None:
         return ProviderStatus.INCOMPLETE, "missing usage metadata", None, None
 
-    prompt_tokens = getattr(usage_obj, "prompt_tokens", None)
-    completion_tokens = getattr(usage_obj, "completion_tokens", None)
     provider_usage = _provider_usage_from_response_usage(usage_obj)
+    prompt_tokens = provider_usage.tokens_in
+    completion_tokens = provider_usage.tokens_out
     if prompt_tokens is None or completion_tokens is None:
         return (
             ProviderStatus.INCOMPLETE,
@@ -199,132 +209,76 @@ def _raw_content_missing(message: Any) -> bool:
     return raw_content is None or raw_content == ""
 
 
-def _content_failure_response(
-    *,
-    provider: str,
-    model: str,
-    attempts: int,
-    usage: ProviderUsage | None,
-    content_part_count: int | None,
-    raw_finish_reason: Any,
-    failure_reason: FailureReason,
-    extraction_notes: str,
-) -> ProviderResponse:
-    return _failed_response(
-        provider=provider,
-        model=model,
-        attempts=attempts,
-        usage=usage,
-        failure_reason=failure_reason,
-        content_source="choices[0].message.content",
-        content_part_count=content_part_count,
-        raw_finish_reason=str(raw_finish_reason) if raw_finish_reason is not None else None,
-        extraction_notes=extraction_notes,
-    )
-
-
 def _extract_content_and_finish_reason(
     *,
     message: Any,
     choice: Any,
-    provider: str,
-    model: str,
-    attempts: int,
-    usage: ProviderUsage | None,
     completion_tokens: int | None,
-) -> tuple[TextPayload, ProviderStatus, str | None] | ProviderResponse:
+) -> ContentExtractionResult:
     raw_finish_reason = getattr(choice, "finish_reason", None)
+    raw_finish_reason_value = str(raw_finish_reason) if raw_finish_reason is not None else None
     text, content_part_count = _content_from_message(message)
     parsed_obj = getattr(message, "parsed", None)
     parsed_value = parsed_obj if isinstance(parsed_obj, BaseModel) else None
     if parsed_value is not None:
-        return (
-            TextPayload(
+        return ContentExtractionResult(
+            payload=TextPayload(
                 text=text or "",
                 finish_reason=_finish_reason_from_raw(raw_finish_reason),
                 parsed=parsed_value,
             ),
-            ProviderStatus.OK if usage is not None else ProviderStatus.INCOMPLETE,
-            None if usage is not None else "missing usage metadata",
+            failure_reason=None,
+            extraction_notes=None,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason_value,
         )
 
     if text is None:
-        return _content_failure_response(
-            provider=provider,
-            model=model,
-            attempts=attempts,
-            usage=usage,
-            content_part_count=content_part_count,
-            raw_finish_reason=raw_finish_reason,
+        return ContentExtractionResult(
+            payload=None,
             failure_reason=FailureReason.CONTENT_FIELD_MISSING,
             extraction_notes="message.content was missing",
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason_value,
         )
 
     if text != "":
-        return (
-            TextPayload(
+        return ContentExtractionResult(
+            payload=TextPayload(
                 text=text,
                 finish_reason=_finish_reason_from_raw(raw_finish_reason),
                 parsed=None,
             ),
-            ProviderStatus.OK if usage is not None else ProviderStatus.INCOMPLETE,
-            None if usage is not None else "missing usage metadata",
+            failure_reason=None,
+            extraction_notes=None,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason_value,
         )
 
     if completion_tokens is not None and completion_tokens > 0:
-        return _content_failure_response(
-            provider=provider,
-            model=model,
-            attempts=attempts,
-            usage=usage,
-            content_part_count=content_part_count,
-            raw_finish_reason=raw_finish_reason,
+        return ContentExtractionResult(
+            payload=None,
             failure_reason=FailureReason.EMPTY_CONTENT_WITH_TOKENS,
             extraction_notes=f"message.content was empty; completion_tokens={completion_tokens}",
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason_value,
         )
 
     if _raw_content_missing(message):
-        return _content_failure_response(
-            provider=provider,
-            model=model,
-            attempts=attempts,
-            usage=usage,
-            content_part_count=content_part_count,
-            raw_finish_reason=raw_finish_reason,
+        return ContentExtractionResult(
+            payload=None,
             failure_reason=FailureReason.CONTENT_FIELD_MISSING,
             extraction_notes="message.content was empty with no completion tokens",
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason_value,
         )
 
-    return _content_failure_response(
-        provider=provider,
-        model=model,
-        attempts=attempts,
-        usage=usage,
-        content_part_count=content_part_count,
-        raw_finish_reason=raw_finish_reason,
+    return ContentExtractionResult(
+        payload=None,
         failure_reason=FailureReason.UNSUPPORTED_RESPONSE_SHAPE,
         extraction_notes=f"unsupported content type: {type(getattr(message, 'content', None)).__name__}",
-    )
-
-
-def _build_success_response(
-    *,
-    provider: str,
-    model: str,
-    attempts: int,
-    payload: TextPayload,
-    status: ProviderStatus,
-    usage: ProviderUsage | None,
-    incomplete_reason: str | None,
-) -> ProviderResponse:
-    return ProviderResponse(
-        provider=provider,
-        model=model,
-        status=status,
-        attempts=attempts,
-        payload=payload,
-        usage=usage,
-        incomplete_reason=incomplete_reason,
+        content_part_count=content_part_count,
+        raw_finish_reason=raw_finish_reason_value,
     )
 
 
@@ -471,25 +425,30 @@ class OpenAIAdapter:
             status, incomplete_reason, provider_usage, completion_tokens = _usage_from_openai_response(
                 response
             )
-            extracted = _extract_content_and_finish_reason(
+            extraction = _extract_content_and_finish_reason(
                 message=message,
                 choice=choice,
-                provider=provider,
-                model=model,
-                attempts=attempts,
-                usage=provider_usage,
                 completion_tokens=completion_tokens,
             )
-            if isinstance(extracted, ProviderResponse):
-                return extracted
+            if extraction.payload is None:
+                return _failed_response(
+                    provider=provider,
+                    model=model,
+                    attempts=attempts,
+                    usage=provider_usage,
+                    failure_reason=extraction.failure_reason or FailureReason.CONTENT_EXTRACTION_ERROR,
+                    content_source="choices[0].message.content",
+                    content_part_count=extraction.content_part_count,
+                    raw_finish_reason=extraction.raw_finish_reason,
+                    extraction_notes=extraction.extraction_notes or "unknown content extraction failure",
+                )
 
-            payload, _, _ = extracted
-            return _build_success_response(
+            return ProviderResponse(
                 provider=provider,
                 model=model,
-                attempts=attempts,
-                payload=payload,
                 status=status,
+                attempts=attempts,
+                payload=extraction.payload,
                 usage=provider_usage,
                 incomplete_reason=incomplete_reason,
             )

--- a/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
@@ -36,7 +36,9 @@ from pydantic import BaseModel
 
 from tnh_scholar.gen_ai_service.models.domain import Message
 from tnh_scholar.gen_ai_service.models.transport import (
+    AdapterDiagnostics,
     FinishReason,
+    FailureReason,
     ProviderRequest,
     ProviderResponse,
     ProviderStatus,
@@ -55,6 +57,275 @@ class OpenAIChatCompletionRequest(BaseModel):
     max_completion_tokens: int
     seed: Optional[int] = None
     response_format: Optional[type[BaseModel]] = None
+
+
+def _finish_reason_from_raw(raw_finish_reason: Any) -> FinishReason:
+    if isinstance(raw_finish_reason, str):
+        finish_reason_map = {
+            "stop": FinishReason.STOP,
+            "length": FinishReason.LENGTH,
+            "content_filter": FinishReason.CONTENT_FILTER,
+            "tool_calls": FinishReason.TOOL_CALLS,
+            "function_call": FinishReason.FUNCTION_CALL,
+            "null": FinishReason.OTHER,
+        }
+        return finish_reason_map.get(raw_finish_reason, FinishReason.OTHER)
+    return FinishReason.OTHER
+
+
+def _content_from_message(message: Any) -> tuple[str | None, int | None]:
+    content = getattr(message, "content", None)
+    if content is None:
+        return None, None
+    if isinstance(content, str):
+        return content, None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            part_type = None
+            part_text = None
+            if isinstance(part, dict):
+                part_type = part.get("type")
+                part_text = part.get("text")
+            else:
+                part_type = getattr(part, "type", None)
+                part_text = getattr(part, "text", None)
+            if part_type == "text" and part_text is not None:
+                parts.append(str(part_text))
+        return "".join(parts), len(content)
+    return None, None
+
+
+def _failed_response(
+    *,
+    provider: str,
+    model: str,
+    attempts: int,
+    usage: ProviderUsage | None,
+    failure_reason: FailureReason,
+    content_source: str,
+    content_part_count: int | None,
+    raw_finish_reason: str | None,
+    extraction_notes: str,
+) -> ProviderResponse:
+    return ProviderResponse(
+        provider=provider,
+        model=model,
+        status=ProviderStatus.FAILED,
+        attempts=attempts,
+        payload=None,
+        usage=usage,
+        failure_reason=failure_reason,
+        adapter_diagnostics=AdapterDiagnostics(
+            content_source=content_source,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason,
+            extraction_notes=extraction_notes,
+        ),
+    )
+
+
+def _provider_usage_from_response_usage(usage_obj: Any) -> ProviderUsage:
+    prompt_tokens = getattr(usage_obj, "prompt_tokens", None)
+    completion_tokens = getattr(usage_obj, "completion_tokens", None)
+    total_tokens = getattr(usage_obj, "total_tokens", None)
+    provider_breakdown = usage_obj.dict() if hasattr(usage_obj, "dict") else {}
+    return ProviderUsage(
+        tokens_in=prompt_tokens,
+        tokens_out=completion_tokens,
+        tokens_total=total_tokens,
+        provider_breakdown=provider_breakdown,
+    )
+
+
+def _validate_response_structure(
+    response: ChatCompletion,
+    *,
+    provider: str,
+    model: str,
+    attempts: int,
+) -> tuple[Any, Any] | ProviderResponse:
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return _failed_response(
+            provider=provider,
+            model=model,
+            attempts=attempts,
+            usage=None,
+            failure_reason=FailureReason.UNSUPPORTED_RESPONSE_SHAPE,
+            content_source="choices[0].message.content",
+            content_part_count=None,
+            raw_finish_reason=None,
+            extraction_notes="response.choices was empty",
+        )
+
+    choice = choices[0]
+    message = getattr(choice, "message", None)
+    if message is None:
+        return _failed_response(
+            provider=provider,
+            model=model,
+            attempts=attempts,
+            usage=None,
+            failure_reason=FailureReason.UNSUPPORTED_RESPONSE_SHAPE,
+            content_source="choices[0].message.content",
+            content_part_count=None,
+            raw_finish_reason=str(getattr(choice, "finish_reason", None)),
+            extraction_notes="choices[0].message was missing",
+        )
+    return choice, message
+
+
+def _usage_from_openai_response(response: ChatCompletion) -> tuple[ProviderStatus, str | None, ProviderUsage | None, int | None]:
+    usage_obj = getattr(response, "usage", None)
+    if usage_obj is None:
+        return ProviderStatus.INCOMPLETE, "missing usage metadata", None, None
+
+    prompt_tokens = getattr(usage_obj, "prompt_tokens", None)
+    completion_tokens = getattr(usage_obj, "completion_tokens", None)
+    provider_usage = _provider_usage_from_response_usage(usage_obj)
+    if prompt_tokens is None or completion_tokens is None:
+        return (
+            ProviderStatus.INCOMPLETE,
+            "partial usage metadata: missing prompt_tokens or completion_tokens",
+            provider_usage,
+            completion_tokens,
+        )
+    return ProviderStatus.OK, None, provider_usage, completion_tokens
+
+
+def _raw_content_missing(message: Any) -> bool:
+    raw_content = getattr(message, "content", None)
+    return raw_content is None or raw_content == ""
+
+
+def _content_failure_response(
+    *,
+    provider: str,
+    model: str,
+    attempts: int,
+    usage: ProviderUsage | None,
+    content_part_count: int | None,
+    raw_finish_reason: Any,
+    failure_reason: FailureReason,
+    extraction_notes: str,
+) -> ProviderResponse:
+    return _failed_response(
+        provider=provider,
+        model=model,
+        attempts=attempts,
+        usage=usage,
+        failure_reason=failure_reason,
+        content_source="choices[0].message.content",
+        content_part_count=content_part_count,
+        raw_finish_reason=str(raw_finish_reason) if raw_finish_reason is not None else None,
+        extraction_notes=extraction_notes,
+    )
+
+
+def _extract_content_and_finish_reason(
+    *,
+    message: Any,
+    choice: Any,
+    provider: str,
+    model: str,
+    attempts: int,
+    usage: ProviderUsage | None,
+    completion_tokens: int | None,
+) -> tuple[TextPayload, ProviderStatus, str | None] | ProviderResponse:
+    raw_finish_reason = getattr(choice, "finish_reason", None)
+    text, content_part_count = _content_from_message(message)
+    parsed_obj = getattr(message, "parsed", None)
+    parsed_value = parsed_obj if isinstance(parsed_obj, BaseModel) else None
+    if parsed_value is not None:
+        return (
+            TextPayload(
+                text=text or "",
+                finish_reason=_finish_reason_from_raw(raw_finish_reason),
+                parsed=parsed_value,
+            ),
+            ProviderStatus.OK if usage is not None else ProviderStatus.INCOMPLETE,
+            None if usage is not None else "missing usage metadata",
+        )
+
+    if text is None:
+        return _content_failure_response(
+            provider=provider,
+            model=model,
+            attempts=attempts,
+            usage=usage,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason,
+            failure_reason=FailureReason.CONTENT_FIELD_MISSING,
+            extraction_notes="message.content was missing",
+        )
+
+    if text != "":
+        return (
+            TextPayload(
+                text=text,
+                finish_reason=_finish_reason_from_raw(raw_finish_reason),
+                parsed=None,
+            ),
+            ProviderStatus.OK if usage is not None else ProviderStatus.INCOMPLETE,
+            None if usage is not None else "missing usage metadata",
+        )
+
+    if completion_tokens is not None and completion_tokens > 0:
+        return _content_failure_response(
+            provider=provider,
+            model=model,
+            attempts=attempts,
+            usage=usage,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason,
+            failure_reason=FailureReason.EMPTY_CONTENT_WITH_TOKENS,
+            extraction_notes=f"message.content was empty; completion_tokens={completion_tokens}",
+        )
+
+    if _raw_content_missing(message):
+        return _content_failure_response(
+            provider=provider,
+            model=model,
+            attempts=attempts,
+            usage=usage,
+            content_part_count=content_part_count,
+            raw_finish_reason=raw_finish_reason,
+            failure_reason=FailureReason.CONTENT_FIELD_MISSING,
+            extraction_notes="message.content was empty with no completion tokens",
+        )
+
+    return _content_failure_response(
+        provider=provider,
+        model=model,
+        attempts=attempts,
+        usage=usage,
+        content_part_count=content_part_count,
+        raw_finish_reason=raw_finish_reason,
+        failure_reason=FailureReason.UNSUPPORTED_RESPONSE_SHAPE,
+        extraction_notes=f"unsupported content type: {type(getattr(message, 'content', None)).__name__}",
+    )
+
+
+def _build_success_response(
+    *,
+    provider: str,
+    model: str,
+    attempts: int,
+    payload: TextPayload,
+    status: ProviderStatus,
+    usage: ProviderUsage | None,
+    incomplete_reason: str | None,
+) -> ProviderResponse:
+    return ProviderResponse(
+        provider=provider,
+        model=model,
+        status=status,
+        attempts=attempts,
+        payload=payload,
+        usage=usage,
+        incomplete_reason=incomplete_reason,
+    )
 
 
 class OpenAIAdapter:
@@ -133,13 +404,13 @@ class OpenAIAdapter:
         )
 
     def from_openai_response(
-        self, 
-        response: ChatCompletion, 
-        *, 
-        model: str, 
+        self,
+        response: ChatCompletion,
+        *,
+        model: str,
         provider: str,
         attempts: int,
-        ) -> ProviderResponse:
+    ) -> ProviderResponse:
         """
         Map OpenAI ChatCompletion → ProviderResponse (transport envelope).
 
@@ -186,67 +457,60 @@ class OpenAIAdapter:
         - Add automated version drift check to flag re-validation when SDK updates.
         """
         
-        # Finish reason mapping:
-        # OpenAI → our FinishReason. Unknown values MUST map to OTHER.
-        # When adding new mapping, update docs/providers/openai_adapter.md and tests.
-        finish_reason_map = {
-            "stop": FinishReason.STOP,
-            "length": FinishReason.LENGTH,
-            "content_filter": FinishReason.CONTENT_FILTER,
-            "tool_calls": FinishReason.TOOL_CALLS,
-            "function_call": FinishReason.FUNCTION_CALL,
-            "null": FinishReason.OTHER,
-        }
-        raw_finish_reason = getattr(response.choices[0], "finish_reason", None)
-        if isinstance(raw_finish_reason, str):
-            finish_reason = finish_reason_map.get(raw_finish_reason, FinishReason.OTHER)
-        else:
-            finish_reason = FinishReason.OTHER
-
-        # NOTE: We access choices[0].message.content.
-        #   - ChatCompletion.choices is guaranteed non-empty for successful completions,
-        #     per openai/types/chat/chat_completion.py (v2.5.0).
-        #   - For safety, future hardening may add a guard for empty choices.
-        message = response.choices[0].message
-        text = message.content or ""
-        parsed_obj = getattr(message, "parsed", None)
-        parsed_value = parsed_obj if isinstance(parsed_obj, BaseModel) else None
-
-        u = getattr(response, "usage", None)
-        provider_usage = None
-        status = ProviderStatus.OK
-        incomplete_reason = None
-        if u is not None:
-            prompt_tokens = getattr(u, "prompt_tokens", None)
-            completion_tokens = getattr(u, "completion_tokens", None)
-            total_tokens = getattr(u, "total_tokens", None)
-            provider_breakdown = u.dict() if hasattr(u, "dict") else {}
-            provider_usage = ProviderUsage(
-                tokens_in=prompt_tokens,
-                tokens_out=completion_tokens,
-                tokens_total=total_tokens,
-                provider_breakdown=provider_breakdown,
+        try:
+            structure = _validate_response_structure(
+                response,
+                provider=provider,
+                model=model,
+                attempts=attempts,
             )
-            if prompt_tokens is None or completion_tokens is None:
-                status = ProviderStatus.INCOMPLETE
-                incomplete_reason = "partial usage metadata: missing prompt_tokens or completion_tokens"
-        else:
-            status = ProviderStatus.INCOMPLETE
-            incomplete_reason = "missing usage metadata"
+            if isinstance(structure, ProviderResponse):
+                return structure
 
-        return ProviderResponse(
-            provider=provider,
-            model=model,
-            status=status,
-            attempts=attempts,
-            payload=TextPayload(
-                text=text,
-                finish_reason=finish_reason,
-                parsed=parsed_value,
-            ),
-            usage=provider_usage,
-            incomplete_reason=incomplete_reason,
-        )
+            choice, message = structure
+            status, incomplete_reason, provider_usage, completion_tokens = _usage_from_openai_response(
+                response
+            )
+            extracted = _extract_content_and_finish_reason(
+                message=message,
+                choice=choice,
+                provider=provider,
+                model=model,
+                attempts=attempts,
+                usage=provider_usage,
+                completion_tokens=completion_tokens,
+            )
+            if isinstance(extracted, ProviderResponse):
+                return extracted
+
+            payload, _, _ = extracted
+            return _build_success_response(
+                provider=provider,
+                model=model,
+                attempts=attempts,
+                payload=payload,
+                status=status,
+                usage=provider_usage,
+                incomplete_reason=incomplete_reason,
+            )
+        except Exception as exc:
+            raw_usage = getattr(response, "usage", None)
+            provider_usage = (
+                _provider_usage_from_response_usage(raw_usage)
+                if raw_usage is not None
+                else None
+            )
+            return _failed_response(
+                provider=provider,
+                model=model,
+                attempts=attempts,
+                usage=provider_usage,
+                failure_reason=FailureReason.CONTENT_EXTRACTION_ERROR,
+                content_source="choices[0].message.content",
+                content_part_count=None,
+                raw_finish_reason=None,
+                extraction_notes=str(exc),
+            )
 
 
 # 🔒 Compatibility Checklist (update when bumping OpenAI SDK or models):

--- a/src/tnh_scholar/gen_ai_service/safety/safety_gate.py
+++ b/src/tnh_scholar/gen_ai_service/safety/safety_gate.py
@@ -19,7 +19,9 @@ from tnh_scholar.gen_ai_service.config.registry import (
 )
 from tnh_scholar.gen_ai_service.config.settings import GenAISettings
 from tnh_scholar.gen_ai_service.models.domain import (
+    CompletionEnvelope,
     CompletionResult,
+    CompletionOutcomeStatus,
     Message,
     RenderedPrompt,
     Role,
@@ -137,7 +139,12 @@ def pre_check(
         selection.max_output_tokens,
     )
     if estimated_cost > settings.max_dollars:
-        raise SafetyBlocked(f"Estimated cost {estimated_cost:.4f} exceeds budget {settings.max_dollars:.4f}")
+        raise SafetyBlocked(
+            f"Estimated cost {estimated_cost:.4f} exceeds budget {settings.max_dollars:.4f}",
+            blocked_reason="budget",
+            estimated_cost=estimated_cost,
+            max_dollars=settings.max_dollars,
+        )
 
     if prompt_metadata and prompt_metadata.safety_level == "sensitive":
         warnings.append("prompt-metadata: sensitive content")
@@ -150,21 +157,11 @@ def pre_check(
     )
 
 
-def post_check(result: CompletionResult | None) -> list[str]:
+def post_check(result: CompletionResult | CompletionEnvelope | None) -> list[str]:
+    """Compatibility hook retained for future post-generation policy checks.
+
+    Typed completion outcome is now authoritative. Empty-text detection is owned
+    by the adapter/mapper path, so this hook intentionally avoids adding soft
+    warnings that could contradict `CompletionEnvelope.outcome`.
     """
-    Post-generation validation hooks (stubbed for now).
-
-    Args:
-        result: CompletionResult or None when provider response missing.
-
-    Returns:
-        List of warning codes (empty when no issues detected).
-    """
-    warnings: list[str] = []
-    if result is None:
-        return warnings
-
-    if not result.text:
-        warnings.append("empty-result")
-
-    return warnings
+    return []

--- a/src/tnh_scholar/gen_ai_service/service.py
+++ b/src/tnh_scholar/gen_ai_service/service.py
@@ -109,16 +109,12 @@ class GenAIService:
             attempt_count=response.attempts,
         )
 
-        envelope = provider_to_completion(
+        return provider_to_completion(
             response,
             provenance=provenance,
             policy_applied=_build_policy_applied(selection.routing_reason, safety_report),
             warnings=list(safety_report.warnings),
         )
-
-        post_warnings = safety_gate.post_check(envelope.result)
-        envelope.warnings.extend(post_warnings)
-        return envelope
 
 
 def _build_policy_applied(

--- a/src/tnh_scholar/metadata/metadata.py
+++ b/src/tnh_scholar/metadata/metadata.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import MutableMapping
 from copy import deepcopy
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Union
 
@@ -44,6 +44,7 @@ class Metadata(MutableMapping):
     # Type processors at class level
     _type_processors = {
         Path: lambda p: path_as_str(p),
+        date: lambda d: d.isoformat(),
         datetime: lambda d: d.isoformat(),
     }
 

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -1,23 +1,33 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timedelta
+from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
 from typer.testing import CliRunner
+import yaml
 
 from tnh_scholar.cli_tools.tnh_gen import tnh_gen
 from tnh_scholar.cli_tools.tnh_gen.commands import run as run_module
 from tnh_scholar.cli_tools.tnh_gen.errors import ExitCode
+from tnh_scholar.cli_tools.tnh_gen.config_loader import CLIConfig
+from tnh_scholar.cli_tools.tnh_gen.state import ctx as cli_ctx
 from tnh_scholar.gen_ai_service.models.domain import (
+    AdapterDiagnostics,
+    CompletionFailure,
     CompletionEnvelope,
+    CompletionOutcomeStatus,
     CompletionResult,
+    FailureReason,
     Fingerprint,
     Provenance,
     Usage,
 )
 from tnh_scholar.gen_ai_service.pattern_catalog.adapters.prompts_adapter import PromptsAdapter
+from tnh_scholar.gen_ai_service.models.errors import SafetyBlocked
 from tnh_scholar.prompt_system.domain.models import PromptMetadata
 
 runner = CliRunner(mix_stderr=False)
@@ -255,6 +265,55 @@ def test_list_default_human_output(tmp_path, monkeypatch):
     assert not result.stdout.lstrip().startswith("{")
 
 
+def test_global_prompt_dir_is_applied_and_restored(tmp_path, monkeypatch):
+    prompt_dir = tmp_path / "custom-prompts"
+    prompt_dir.mkdir()
+    prompt_dir.joinpath("custom.md").write_text(
+        dedent(
+            """\
+            ---
+            key: custom
+            name: Custom Prompt
+            version: 1.0.0
+            description: Custom prompt for testing.
+            task_type: study-plan
+            required_variables: []
+            optional_variables: []
+            default_variables: {}
+            tags: []
+            ---
+            # Custom Prompt
+            """
+        ),
+            encoding="utf-8",
+        )
+    monkeypatch.setenv("TNH_PROMPT_DIR", "sentinel")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+
+    result = runner.invoke(tnh_gen.app, ["--prompt-dir", str(prompt_dir), "list", "--keys-only"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "custom"
+    assert os.environ.get("TNH_PROMPT_DIR") == "sentinel"
+
+
+def test_global_prompt_dir_is_restored_after_error(tmp_path, monkeypatch):
+    prompt_dir = tmp_path / "custom-prompts"
+    prompt_dir.mkdir()
+    prompt_dir.joinpath("custom.md").write_text("# Custom Prompt\n", encoding="utf-8")
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", "sentinel")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+
+    result = runner.invoke(
+        tnh_gen.app,
+        ["--prompt-dir", str(prompt_dir), "--api", "list", "--format", "text"],
+    )
+
+    assert result.exit_code != 0
+    assert os.environ.get("TNH_PROMPT_DIR") == "sentinel"
+
+
 def test_list_api_rejects_text_format(tmp_path, monkeypatch):
     prompt_dir = _write_prompt(tmp_path)
     monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
@@ -300,6 +359,7 @@ class _StubService:
         started = datetime.now()
         finished = started + timedelta(seconds=1)
         return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.SUCCEEDED,
             result=CompletionResult(
                 text="generated text",
                 usage=Usage(
@@ -329,6 +389,92 @@ class _StubService:
         )
 
 
+class _IncompleteStubService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+        self._metadata = metadata
+
+    def generate(self, request):
+        self.last_request = request
+        started = datetime.now()
+        finished = started + timedelta(seconds=1)
+        return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.INCOMPLETE,
+            result=CompletionResult(
+                text="partial text",
+                usage=Usage(
+                    prompt_tokens=8,
+                    completion_tokens=12,
+                    total_tokens=20,
+                ),
+                model="gpt-4o",
+                provider="openai",
+                finish_reason="length",
+            ),
+            provenance=Provenance(
+                provider="openai",
+                model="gpt-4o",
+                started_at=started,
+                finished_at=finished,
+                attempt_count=1,
+                fingerprint=Fingerprint(
+                    prompt_key="daily",
+                    prompt_name="Daily Guidance",
+                    prompt_base_path=".",
+                    prompt_content_hash="hash-prompt",
+                    variables_hash="hash-vars",
+                    user_string_hash="hash-input",
+                ),
+            ),
+            policy_applied={"routing_reason": "test"},
+            warnings=["provider-status:incomplete"],
+        )
+
+
+class _FailedStubService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+        self._metadata = metadata
+
+    def generate(self, request):
+        self.last_request = request
+        started = datetime.now()
+        finished = started + timedelta(seconds=1)
+        return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.FAILED,
+            failure=CompletionFailure(
+                reason=FailureReason.CONTENT_EXTRACTION_ERROR,
+                message="backend failure",
+                retryable=False,
+                adapter_diagnostics=AdapterDiagnostics(
+                    content_source="choices[0].message.content",
+                    content_part_count=None,
+                    raw_finish_reason="stop",
+                    extraction_notes="adapter could not parse content",
+                ),
+            ),
+            provenance=Provenance(
+                provider="openai",
+                model="gpt-4o",
+                started_at=started,
+                finished_at=finished,
+                attempt_count=1,
+                fingerprint=Fingerprint(
+                    prompt_key="daily",
+                    prompt_name="Daily Guidance",
+                    prompt_base_path=".",
+                    prompt_content_hash="hash-prompt",
+                    variables_hash="hash-vars",
+                    user_string_hash="hash-input",
+                ),
+            ),
+            policy_applied={"routing_reason": "test"},
+            warnings=["provider-status:failed"],
+        )
+
+
 class _CatalogBackedStubService:
     """Stub service that uses a real catalog for metadata warnings."""
 
@@ -342,6 +488,7 @@ class _CatalogBackedStubService:
         started = datetime.now()
         finished = started + timedelta(seconds=1)
         return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.SUCCEEDED,
             result=CompletionResult(
                 text="generated text",
                 usage=Usage(prompt_tokens=5, completion_tokens=5, total_tokens=10),
@@ -367,6 +514,33 @@ class _CatalogBackedStubService:
             policy_applied={"routing_reason": "test"},
             warnings=[],
         )
+
+
+class _BudgetBlockedService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+
+    def generate(self, request):
+        self.last_request = request
+        raise SafetyBlocked(
+            "Estimated cost 0.0420 exceeds budget 0.0200",
+            blocked_reason="budget",
+            estimated_cost=0.042,
+            max_dollars=0.02,
+        )
+
+
+class _RecordingFactory:
+    def __init__(self, service: Any):
+        self.service = service
+        self.last_config: CLIConfig | None = None
+        self.last_overrides: Any = None
+
+    def create_genai_service(self, cli_config: CLIConfig, overrides: Any):
+        self.last_config = cli_config
+        self.last_overrides = overrides
+        return self.service
 
 
 def test_run_missing_required_variables_returns_error(tmp_path, monkeypatch):
@@ -502,6 +676,7 @@ def test_run_merges_variables_and_writes_file(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
+    assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["status"] == "succeeded"
     assert payload["result"]["text"] == "generated text"
@@ -517,6 +692,425 @@ def test_run_merges_variables_and_writes_file(tmp_path, monkeypatch):
     assert "tnh_scholar_generated: true" in written
     assert "prompt_key: daily" in written
     assert "generated text" in written
+
+
+def test_run_strips_input_frontmatter_and_merges_output_metadata(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.md"
+    input_file.write_text(
+        (
+            "---\n"
+            "source: draft\n"
+            "prompt_key: user-value\n"
+            "---\n"
+            "file-input\n"
+        ),
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _StubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "out.txt"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    assert stub_service.last_request.user_input.strip() == "file-input"
+    assert stub_service.last_request.variables["input_text"].strip() == "file-input"
+
+    written = output_file.read_text(encoding="utf-8")
+    header, body = written.split("---\n", 2)[1:]
+    payload = yaml.safe_load(header)
+
+    assert payload["source"] == "draft"
+    assert payload["prompt_key"] == "daily"
+    assert payload["tnh_scholar_generated"] is True
+    assert body.lstrip("\n") == "generated text"
+
+
+def test_run_preserves_yaml_date_frontmatter(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.md"
+    input_file.write_text(
+        (
+            "---\n"
+            "date: 2026-04-17\n"
+            "source: draft\n"
+            "---\n"
+            "file-input\n"
+        ),
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _StubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "out.txt"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    written = output_file.read_text(encoding="utf-8")
+    header = written.split("---\n", 2)[1]
+    payload = yaml.safe_load(header)
+    assert payload["date"] == "2026-04-17"
+
+
+def test_run_accepts_forwarded_config_api_and_prompt_dir(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "default_model": "from-config",
+                "prompt_catalog_dir": str(tmp_path / "wrong-prompts"),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    factory = _RecordingFactory(_StubService(metadata))
+
+    monkeypatch.delenv("TNH_PROMPT_DIR", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(cli_ctx, "service_factory", factory)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--api",
+            "--prompt-dir",
+            str(prompt_dir),
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "succeeded"
+    assert factory.last_config is not None
+    assert factory.last_config.default_model == "from-config"
+    assert factory.last_config.prompt_catalog_dir == Path(prompt_dir)
+
+
+def test_run_api_incomplete_returns_payload_and_writes_file(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _IncompleteStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "incomplete.txt"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "incomplete"
+    assert payload["result"]["text"] == "partial text"
+    assert payload["result"]["finish_reason"] == "length"
+    assert payload["provenance"]["prompt_key"] == "daily"
+    assert output_file.exists()
+    assert "partial text" in output_file.read_text(encoding="utf-8")
+
+
+def test_run_api_failed_completion_returns_failure_payload_without_file(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _FailedStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "failed.txt"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.PROVIDER_ERROR
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert payload["failure"]["reason"] == FailureReason.CONTENT_EXTRACTION_ERROR.value
+    assert payload["failure"]["message"] == "backend failure"
+    assert payload["failure"]["adapter_diagnostics"]["content_source"] == "choices[0].message.content"
+    assert not output_file.exists()
+
+
+def test_run_api_budget_block_returns_structured_payload(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    factory = _RecordingFactory(_BudgetBlockedService(metadata))
+
+    monkeypatch.delenv("TNH_PROMPT_DIR", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(cli_ctx, "service_factory", factory)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "run",
+            "--api",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+        ],
+    )
+
+    assert result.exit_code == ExitCode.POLICY_ERROR
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["blocked_reason"] == "budget"
+    assert payload["estimated_cost"] == 0.042
+    assert payload["max_dollars"] == 0.02
+    assert payload["trace_id"]
+
+
+def test_run_human_budget_block_reports_actionable_text(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    factory = _RecordingFactory(_BudgetBlockedService(metadata))
+
+    monkeypatch.delenv("TNH_PROMPT_DIR", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(cli_ctx, "service_factory", factory)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+        ],
+    )
+
+    assert result.exit_code == ExitCode.POLICY_ERROR
+    assert "Budget blocked" in result.stdout
+    assert "Raise max_dollars in config" in result.stdout
+    assert "tnh-gen config set --workspace max_dollars 0.10" in result.stdout
+    assert "trace_id=" in result.stderr
+
+
+def test_run_human_mode_failed_completion_reports_error_and_skips_output_file(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _FailedStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "failed.txt"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--var",
+            "audience=students",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.PROVIDER_ERROR
+    assert "Error:" in result.stdout
+    assert "backend failure" in result.stdout
+    assert "[warn]" in result.stderr
+    assert "trace_id=" in result.stderr
+    assert not output_file.exists()
 
 
 def test_run_human_mode_outputs_text_only(tmp_path, monkeypatch):
@@ -854,6 +1448,7 @@ def test_legacy_prompt_run_uses_fallback_metadata_and_input_text(tmp_path, monke
     )
 
     assert result.exit_code == 0, result.output
+    assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["status"] == "succeeded"
     assert payload["prompt_warnings"]

--- a/tests/cli_tools/test_tnh_gen_coverage.py
+++ b/tests/cli_tools/test_tnh_gen_coverage.py
@@ -36,12 +36,14 @@ from tnh_scholar.cli_tools.tnh_gen.state import ListOutputFormat, OutputFormat, 
 from tnh_scholar.exceptions import ConfigurationError, ExternalServiceError, ValidationError
 from tnh_scholar.gen_ai_service.models.domain import (
     CompletionEnvelope,
+    CompletionOutcomeStatus,
     CompletionResult,
     Fingerprint,
     Provenance,
     Usage,
 )
 from tnh_scholar.gen_ai_service.models.errors import ProviderError
+from tnh_scholar.metadata import Metadata
 from tnh_scholar.prompt_system.domain.models import PromptMetadata
 
 runner = CliRunner(mix_stderr=False)
@@ -79,6 +81,7 @@ def _envelope_with_warnings() -> CompletionEnvelope:
     started = datetime.now()
     finished = started
     return CompletionEnvelope(
+        outcome=CompletionOutcomeStatus.SUCCEEDED,
         result=CompletionResult(
             text="generated text",
             usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
@@ -412,15 +415,13 @@ def test_initialize_service_uses_factory_overrides():
 
 
 def test_emit_warnings_respects_quiet(capsys):
-    metadata = _prompt_metadata(warnings=["metadata-warning"])
-    run_module._emit_warnings(_envelope_with_warnings(), metadata, quiet=True)
+    run_module._emit_warnings(_envelope_with_warnings(), quiet=True, api=False)
     captured = capsys.readouterr()
     assert captured.err == ""
 
 
 def test_emit_warnings_outputs_to_stderr(capsys):
-    metadata = _prompt_metadata(warnings=["metadata-warning"])
-    run_module._emit_warnings(_envelope_with_warnings(), metadata, quiet=False)
+    run_module._emit_warnings(_envelope_with_warnings(), quiet=False, api=False)
     captured = capsys.readouterr()
     assert "[warn]" in captured.err
 
@@ -539,6 +540,49 @@ def test_provenance_yaml_roundtrip(tmp_path):
     assert payload["generated_at"].endswith("Z")
     assert payload["schema_version"] == "1.0"
     assert body.lstrip("\n") == "plain text"
+
+
+def test_provenance_merges_source_metadata_and_preserves_it_without_provenance(tmp_path):
+    output_file = tmp_path / "output.txt"
+    envelope = _envelope_with_warnings()
+    source_metadata = Metadata({"source": "draft", "prompt_key": "user-value"})
+    provenance_module.write_output_file(
+        output_file,
+        result_text="plain text",
+        envelope=envelope,
+        source_metadata=source_metadata,
+        trace_id="trace",
+        prompt_version=None,
+        include_provenance=True,
+    )
+
+    written = output_file.read_text(encoding="utf-8")
+    header, body = written.split("---\n", 2)[1:]
+    payload = yaml.safe_load(header)
+
+    assert payload["source"] == "draft"
+    assert payload["prompt_key"] == envelope.provenance.fingerprint.prompt_key
+    assert payload["tnh_scholar_generated"] is True
+    assert body.lstrip("\n") == "plain text"
+
+    plain_output = tmp_path / "plain.txt"
+    provenance_module.write_output_file(
+        plain_output,
+        result_text="plain text",
+        envelope=envelope,
+        source_metadata=source_metadata,
+        trace_id="trace",
+        prompt_version=None,
+        include_provenance=False,
+    )
+
+    plain_written = plain_output.read_text(encoding="utf-8")
+    plain_header, plain_body = plain_written.split("---\n", 2)[1:]
+    plain_payload = yaml.safe_load(plain_header)
+
+    assert plain_payload["source"] == "draft"
+    assert "tnh_scholar_generated" not in plain_payload
+    assert plain_body.lstrip("\n") == "plain text"
 
 
 def test_main_dispatch_calls_app(monkeypatch):

--- a/tests/gen_ai_service/test_completion_mapper.py
+++ b/tests/gen_ai_service/test_completion_mapper.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from tnh_scholar.gen_ai_service.mappers.completion_mapper import provider_to_completion
-from tnh_scholar.gen_ai_service.models.domain import CompletionResult, Fingerprint, Provenance, Usage
+from tnh_scholar.gen_ai_service.models.domain import (
+    AdapterDiagnostics,
+    CompletionFailure,
+    CompletionOutcomeStatus,
+    CompletionResult,
+    FailureReason,
+    Fingerprint,
+    Provenance,
+    Usage,
+)
 from tnh_scholar.gen_ai_service.models.transport import (
     ErrorInfo,
     ErrorKind,
@@ -43,11 +52,22 @@ def test_provider_error_is_mapped_to_envelope():
         payload=None,
         usage=None,
         error=ErrorInfo(kind=ErrorKind.PROVIDER, message="backend failure", code="500"),
+        failure_reason=FailureReason.CONTENT_EXTRACTION_ERROR,
+        adapter_diagnostics=AdapterDiagnostics(
+            content_source="choices[0].message.content",
+            content_part_count=None,
+            raw_finish_reason="stop",
+            extraction_notes="adapter could not parse content",
+        ),
     )
 
     envelope = provider_to_completion(resp, provenance=_provenance())
 
+    assert envelope.outcome == CompletionOutcomeStatus.FAILED
     assert envelope.result is None
+    assert isinstance(envelope.failure, CompletionFailure)
+    assert envelope.failure.reason == FailureReason.CONTENT_EXTRACTION_ERROR
+    assert envelope.failure.adapter_diagnostics is not None
     assert any("provider-status" in w for w in envelope.warnings)
     assert envelope.policy_applied["provider_error_message"] == "backend failure"
 
@@ -64,7 +84,48 @@ def test_provider_response_maps_usage_and_finish_reason():
 
     envelope = provider_to_completion(resp, provenance=_provenance())
 
+    assert envelope.outcome == CompletionOutcomeStatus.SUCCEEDED
     assert isinstance(envelope.result, CompletionResult)
     assert isinstance(envelope.result.usage, Usage)
     assert envelope.result.finish_reason == FinishReason.STOP
     assert envelope.result.usage.total_tokens == 15
+
+
+def test_payloadless_incomplete_response_is_normalized_to_failed():
+    resp = ProviderResponse(
+        provider="openai",
+        model="gpt-test",
+        status=ProviderStatus.INCOMPLETE,
+        attempts=1,
+        payload=None,
+        usage=None,
+        incomplete_reason="missing usage metadata",
+    )
+
+    envelope = provider_to_completion(resp, provenance=_provenance())
+
+    assert envelope.outcome == CompletionOutcomeStatus.FAILED
+    assert envelope.result is None
+    assert envelope.failure is not None
+    assert envelope.failure.reason == FailureReason.CONTENT_FIELD_MISSING
+    assert "provider-missing-payload" in envelope.warnings
+
+
+def test_rate_limited_response_is_normalized_to_failed():
+    resp = ProviderResponse(
+        provider="openai",
+        model="gpt-test",
+        status=ProviderStatus.RATE_LIMITED,
+        attempts=1,
+        payload=None,
+        usage=None,
+        error=ErrorInfo(kind=ErrorKind.RATE_LIMIT, message="too many requests", code="429"),
+    )
+
+    envelope = provider_to_completion(resp, provenance=_provenance())
+
+    assert envelope.outcome == CompletionOutcomeStatus.FAILED
+    assert envelope.result is None
+    assert envelope.failure is not None
+    assert envelope.failure.reason == FailureReason.CONTENT_EXTRACTION_ERROR
+    assert envelope.policy_applied["provider_error_code"] == "429"

--- a/tests/gen_ai_service/test_openai_adapter.py
+++ b/tests/gen_ai_service/test_openai_adapter.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+
+from tnh_scholar.gen_ai_service.models.domain import AdapterDiagnostics, FailureReason
+from tnh_scholar.gen_ai_service.models.transport import ProviderStatus
+from tnh_scholar.gen_ai_service.providers.openai_adapter import OpenAIAdapter
+
+
+class _UsageStub:
+    def __init__(self, *, prompt_tokens: int | None, completion_tokens: int | None, total_tokens: int | None):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = total_tokens
+
+    def dict(self) -> dict[str, int | None]:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+def _response(*, content, finish_reason: str | None = "stop", parsed=None, usage=None, choices=None):
+    if choices is None:
+        message = SimpleNamespace(content=content, parsed=parsed)
+        choices = [SimpleNamespace(message=message, finish_reason=finish_reason)]
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+class _ParsedStub(BaseModel):
+    value: str
+
+
+def test_openai_adapter_marks_empty_content_with_tokens_as_failed():
+    adapter = OpenAIAdapter()
+    response = _response(
+        content="",
+        usage=_UsageStub(prompt_tokens=5, completion_tokens=9, total_tokens=14),
+    )
+
+    provider_response = adapter.from_openai_response(
+        response,
+        model="gpt-test",
+        provider="openai",
+        attempts=2,
+    )
+
+    assert provider_response.status == ProviderStatus.FAILED
+    assert provider_response.failure_reason == FailureReason.EMPTY_CONTENT_WITH_TOKENS
+    assert provider_response.payload is None
+    assert isinstance(provider_response.adapter_diagnostics, AdapterDiagnostics)
+    assert provider_response.adapter_diagnostics.extraction_notes == "message.content was empty; completion_tokens=9"
+
+
+def test_openai_adapter_marks_missing_content_without_tokens_as_failed():
+    adapter = OpenAIAdapter()
+    response = _response(
+        content=None,
+        usage=_UsageStub(prompt_tokens=5, completion_tokens=0, total_tokens=5),
+    )
+
+    provider_response = adapter.from_openai_response(
+        response,
+        model="gpt-test",
+        provider="openai",
+        attempts=1,
+    )
+
+    assert provider_response.status == ProviderStatus.FAILED
+    assert provider_response.failure_reason == FailureReason.CONTENT_FIELD_MISSING
+    assert provider_response.payload is None
+    assert provider_response.adapter_diagnostics is not None
+
+
+def test_openai_adapter_marks_empty_choices_as_failed():
+    adapter = OpenAIAdapter()
+    response = _response(
+        content="unused",
+        choices=[],
+        usage=_UsageStub(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    provider_response = adapter.from_openai_response(
+        response,
+        model="gpt-test",
+        provider="openai",
+        attempts=1,
+    )
+
+    assert provider_response.status == ProviderStatus.FAILED
+    assert provider_response.failure_reason == FailureReason.UNSUPPORTED_RESPONSE_SHAPE
+    assert provider_response.adapter_diagnostics is not None
+
+
+def test_openai_adapter_keeps_parsed_structured_output_successful():
+    adapter = OpenAIAdapter()
+    response = _response(
+        content=None,
+        parsed=_ParsedStub(value="ok"),
+        usage=_UsageStub(prompt_tokens=2, completion_tokens=0, total_tokens=2),
+    )
+
+    provider_response = adapter.from_openai_response(
+        response,
+        model="gpt-test",
+        provider="openai",
+        attempts=1,
+    )
+
+    assert provider_response.status == ProviderStatus.OK
+    assert provider_response.failure_reason is None
+    assert provider_response.payload is not None
+    assert provider_response.payload.parsed == _ParsedStub(value="ok")

--- a/tests/gen_ai_service/test_policy_routing_safety.py
+++ b/tests/gen_ai_service/test_policy_routing_safety.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from tnh_scholar.gen_ai_service.config.params_policy import ResolvedParams, apply_policy
 from tnh_scholar.gen_ai_service.config.settings import GenAISettings
-from tnh_scholar.gen_ai_service.models.domain import CompletionResult, Message, RenderedPrompt, Role
+from tnh_scholar.gen_ai_service.models.domain import (
+    AdapterDiagnostics,
+    CompletionEnvelope,
+    CompletionFailure,
+    CompletionOutcomeStatus,
+    CompletionResult,
+    FailureReason,
+    Fingerprint,
+    Message,
+    Provenance,
+    RenderedPrompt,
+    Role,
+)
 from tnh_scholar.gen_ai_service.models.errors import SafetyBlocked
 from tnh_scholar.gen_ai_service.routing.model_router import select_provider_and_model
 from tnh_scholar.gen_ai_service.safety import safety_gate
@@ -266,5 +280,41 @@ def test_safety_gate_post_check_warns_on_empty_result():
         model="gpt-test",
         provider="openai",
     )
-    warnings = safety_gate.post_check(result)
-    assert "empty-result" in warnings
+    assert safety_gate.post_check(result) == []
+
+
+def test_safety_gate_post_check_ignores_failed_envelope():
+    envelope = CompletionEnvelope(
+        outcome=CompletionOutcomeStatus.FAILED,
+        result=None,
+        failure=CompletionFailure(
+            reason=FailureReason.EMPTY_CONTENT_WITH_TOKENS,
+            message="no text",
+            retryable=False,
+            adapter_diagnostics=AdapterDiagnostics(
+                content_source="choices[0].message.content",
+                content_part_count=None,
+                raw_finish_reason="stop",
+                extraction_notes="empty",
+            ),
+        ),
+        provenance=Provenance(
+            provider="openai",
+            model="gpt-test",
+            sdk_version=None,
+            started_at=datetime.now(UTC),
+            finished_at=datetime.now(UTC),
+            attempt_count=1,
+            fingerprint=Fingerprint(
+                prompt_key="k",
+                prompt_name="n",
+                prompt_base_path="/tmp",
+                prompt_content_hash="abc",
+                variables_hash="def",
+                user_string_hash="ghi",
+            ),
+        ),
+        warnings=[],
+    )
+
+    assert safety_gate.post_check(envelope) == []

--- a/tests/gen_ai_service/test_service.py
+++ b/tests/gen_ai_service/test_service.py
@@ -122,6 +122,7 @@ def test_gen_ai_service_golden_path(tmp_path, monkeypatch: pytest.MonkeyPatch):
 
     assert apply_calls == [("study-plan", None)]
     assert select_calls and select_calls[0][2] is settings
+    assert envelope.outcome.value == "succeeded"
 
     assert len(dummy_client.requests) == 1
     provider_request = dummy_client.requests[0]

--- a/tests/gen_ai_service/utils/test_response_utils.py
+++ b/tests/gen_ai_service/utils/test_response_utils.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from tnh_scholar.gen_ai_service.models.domain import (
     CompletionEnvelope,
+    CompletionOutcomeStatus,
     CompletionResult,
     Fingerprint,
     Provenance,
@@ -34,6 +35,7 @@ class SampleModel(BaseModel):
 def _create_test_envelope(text: str = "Test response") -> CompletionEnvelope:
     """Helper to create a test envelope."""
     return CompletionEnvelope(
+        outcome=CompletionOutcomeStatus.SUCCEEDED,
         result=CompletionResult(
             text=text,
             usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
@@ -72,6 +74,7 @@ def test_extract_text():
 def test_extract_text_no_result():
     """Test extracting text when envelope has no result."""
     envelope = CompletionEnvelope.model_construct(
+        outcome=CompletionOutcomeStatus.FAILED,
         result=None,
         provenance=None,
         policy_applied={},
@@ -162,6 +165,7 @@ def test_extract_provenance():
 def test_extract_provenance_no_provenance():
     """Test extracting provenance when none exists."""
     envelope = CompletionEnvelope.model_construct(
+        outcome=CompletionOutcomeStatus.SUCCEEDED,
         result=_create_test_envelope().result,
         provenance=None,
         policy_applied={},
@@ -208,6 +212,7 @@ def test_is_successful_with_object():
 def test_is_successful_no_result():
     """Test checking success when no result."""
     envelope = CompletionEnvelope.model_construct(
+        outcome=CompletionOutcomeStatus.FAILED,
         result=None,
         provenance=None,
         policy_applied={},


### PR DESCRIPTION
## Summary
Hardens the `tnh-gen` completion contract and run path so failed or unextractable provider responses are represented as typed failures instead of success-shaped empty results.

## What Changed
- adds typed completion outcomes, failure reasons, and adapter diagnostics in the GenAI service domain and transport models
- hardens the OpenAI adapter against empty content, missing content, and unsupported response shapes
- updates the completion mapper and service to preserve typed failure/incomplete state instead of flattening it into warnings
- updates `tnh-gen run` to branch on `succeeded` / `incomplete` / `failed`, avoid writing output files for failed completions, and emit structured API payloads
- preserves input frontmatter through output provenance writing and keeps YAML date values stable
- adds forwarded `--prompt-dir` plumbing for `run` via global CLI/config loader support
- updates changelog/todo tracking for this slice

## Validation
- `PYTHONPATH=/Users/phapman/Desktop/Projects/tnh-scholar-tnh-gen-pr1 /Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/pytest tests/gen_ai_service/test_openai_adapter.py tests/gen_ai_service/test_completion_mapper.py tests/gen_ai_service/test_policy_routing_safety.py tests/gen_ai_service/test_service.py tests/cli_tools/test_tnh_gen.py tests/cli_tools/test_tnh_gen_coverage.py -q`
- `PYTHONPATH=/Users/phapman/Desktop/Projects/tnh-scholar-tnh-gen-pr1 /Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/python scripts/pr_readiness.py --base origin/main`
  - result: `status: ready`, `diff-chars: 103799`

## Follow-up
Prompt catalog health aggregation and `config/list` CLI surfacing remain intentionally out of scope for this PR and will follow in a separate slice.

## Summary by Sourcery

Harden tnh-gen’s completion pipeline and OpenAI adapter to produce typed success/incomplete/failure outcomes, improve CLI run behavior and error handling, and preserve frontmatter metadata in generated outputs.

New Features:
- Introduce typed completion outcome statuses and structured failure reasons with adapter diagnostics across GenAI domain and transport models.
- Extend tnh-gen run API payloads to expose outcome status, failure details, and budget-block metadata, and add support for a global --prompt-dir override.

Bug Fixes:
- Prevent OpenAI completions with empty or missing content, empty choices, or malformed shapes from surfacing as successful empty results.
- Avoid writing output files for failed completions and ensure YAML frontmatter dates and source metadata are preserved consistently.

Enhancements:
- Refine completion mapping to derive outcome and failure objects from provider responses while normalizing warnings and policy metadata.
- Improve safety gating to carry structured budget-block information and simplify post-generation checks to rely on completion outcomes.
- Update provenance and metadata utilities to merge original frontmatter into output files while enforcing that failed completions cannot be written.

Documentation:
- Refresh TODO and changelog entries to reflect the completion and run robustness work and the new prompt-dir flag.

Tests:
- Add focused tests for OpenAI adapter failure mapping, completion mapper outcome handling, safety gate behavior, CLI run error modes, prompt-dir forwarding, and provenance/frontmatter roundtrips.