### PR TITLE
Add tnh-gen catalog health reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **tnh-gen Prompt Catalog Health and Config Reporting** (2026-04-19)
+  - Added typed prompt catalog health models and adapter accumulation so filesystem and git-backed prompt catalogs report parse, validation, and metadata issues without per-prompt warning spam
+  - Updated `tnh-gen list` to emit a single human summary for catalog load failures and to include `catalog_errors` in API output
+  - Added `tnh-gen config show --catalog-health` for structured catalog diagnostics sourced through the shared prompts adapter
+  - Added focused regression coverage for filesystem/git catalog health accumulation and the new CLI reporting paths
+  - Files: `src/tnh_scholar/prompt_system/`, `src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py`, `src/tnh_scholar/cli_tools/tnh_gen/commands/{config,list}.py`, `src/tnh_scholar/cli_tools/tnh_gen/types.py`, `tests/prompt_system/`, `tests/cli_tools/test_tnh_gen.py`
+
 - **tnh-gen Completion Outcome and Run Robustness** (2026-04-18)
   - Added typed completion outcomes, structured failure payloads, and adapter diagnostics across the GenAI service and `tnh-gen run`
   - Hardened the OpenAI adapter against empty, missing, and unsupported response shapes instead of silently returning success-shaped empty text

--- a/TODO.md
+++ b/TODO.md
@@ -5,13 +5,13 @@ owner: ""
 author: ""
 status: processing
 created: "2025-01-20"
-updated: "2026-04-13"
+updated: "2026-04-19"
 ---
 # TNH Scholar TODO List
 
 Roadmap tracking the highest-priority TNH Scholar tasks and release blockers.
 
-> **Last Updated**: 2026-04-18 (tnh-gen completion/run robustness slice landed; bootstrap-proof workflow still next)
+> **Last Updated**: 2026-04-19 (tnh-gen catalog health/config slice ready; bootstrap-proof workflow still next)
 > **Version**: 0.3.1 (Alpha)
 > **Status**: Active Development - Bootstrap path complete, production hardening phase
 >
@@ -29,11 +29,10 @@ Roadmap tracking the highest-priority TNH Scholar tasks and release blockers.
 1. 🔮 **JVB VS Code Parallel Viewer** (P1, design phase) — ADR-JVB02 strategy + UI-UX design
 2. 🔮 Finish yt-dlp reliability suite + monthly ops trigger (P1, reliability)
 3. 🔮 Finish ytt-fetch robustness hardening (P1, reliability)
-4. 🔮 Add `--prompt-dir` Global Flag to tnh-gen (P1, minor)
-5. 🚧 GenAIService Final Polish - promote `policy_applied` typing (P1, minor)
-6. 🚧 Prompt Catalog Safety - error handling, validation (P2, critical infrastructure)
-7. 🚧 Knowledge Base Implementation (P2, design complete)
-8. 🚧 Expand Test Coverage to 50%+ (P2)
+4. 🚧 GenAIService Final Polish - promote `policy_applied` typing (P1, minor)
+5. 🚧 Prompt Catalog Safety - manifest validation + schema docs (P2, critical infrastructure)
+6. 🚧 Knowledge Base Implementation (P2, design complete)
+7. 🚧 Expand Test Coverage to 50%+ (P2)
 
 **For completed items**: See [Archive](#recently-completed-tasks-archive) section at end.
 
@@ -584,14 +583,15 @@ docs/architecture/jvb-viewer/adr/
 
 #### 🚧 Prompt Catalog Safety
 
-- **Status**: NOT STARTED
+- **Status**: IN PROGRESS
 - **Priority**: HIGH (critical infrastructure)
-- **Problem**: Adapter doesn't handle missing keys or invalid front-matter gracefully
+- **Problem**: Catalog health reporting is now in place, but the prompt platform still needs stronger manifest/schema guarantees and clearer operator docs
 - **Tasks**:
+  - [x] Aggregate catalog parse/validation issues into typed health reports
+  - [x] Surface catalog health through `tnh-gen list` and `tnh-gen config show --catalog-health`
   - [ ] Add manifest validation
-  - [ ] Implement caching
   - [ ] Better error messages (unknown prompt, hash mismatch)
-  - [ ] Front-matter validation
+  - [ ] Front-matter/schema validation guidance
   - [ ] Document prompt schema
 
 #### 🚧 Knowledge Base Implementation

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/config.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/config.py
@@ -79,41 +79,13 @@ def _format_config_text(overrides: ConfigData) -> str:
 
 
 def _build_config_data_entry(key: ConfigKey, value: ConfigValue) -> ConfigData:
-    match key:
-        case "prompt_catalog_dir":
-            return {"prompt_catalog_dir": value}
-        case "default_model":
-            return {"default_model": value}
-        case "max_dollars":
-            return {"max_dollars": value}
-        case "max_input_chars":
-            return {"max_input_chars": value}
-        case "default_temperature":
-            return {"default_temperature": value}
-        case "api_key":
-            return {"api_key": value}
-        case "cli_path":
-            return {"cli_path": value}
+    _assert_config_key_supported(key)
+    return cast(ConfigData, {key: value})
 
 
 def _build_config_value_payload(key: ConfigKey, value: ConfigValue, trace_id: str) -> ConfigValuePayload:
-    payload: ConfigValuePayload = {"trace_id": trace_id}
-    match key:
-        case "prompt_catalog_dir":
-            payload["prompt_catalog_dir"] = value
-        case "default_model":
-            payload["default_model"] = value
-        case "max_dollars":
-            payload["max_dollars"] = value
-        case "max_input_chars":
-            payload["max_input_chars"] = value
-        case "default_temperature":
-            payload["default_temperature"] = value
-        case "api_key":
-            payload["api_key"] = value
-        case "cli_path":
-            payload["cli_path"] = value
-    return payload
+    _assert_config_key_supported(key)
+    return cast(ConfigValuePayload, {"trace_id": trace_id, key: value})
 
 
 def _build_config_update(key: ConfigKey, value: str | float | int) -> ConfigData:
@@ -121,21 +93,13 @@ def _build_config_update(key: ConfigKey, value: str | float | int) -> ConfigData
 
 
 def _get_config_value(config: ConfigData, key: ConfigKey) -> ConfigValue:
-    match key:
-        case "prompt_catalog_dir":
-            return config.get("prompt_catalog_dir")
-        case "default_model":
-            return config.get("default_model")
-        case "max_dollars":
-            return config.get("max_dollars")
-        case "max_input_chars":
-            return config.get("max_input_chars")
-        case "default_temperature":
-            return config.get("default_temperature")
-        case "api_key":
-            return config.get("api_key")
-        case "cli_path":
-            return config.get("cli_path")
+    _assert_config_key_supported(key)
+    return cast(ConfigValue, config.get(key))
+
+
+def _assert_config_key_supported(key: ConfigKey) -> None:
+    if key not in available_keys():
+        raise ValueError(f"Unhandled ConfigKey: {key!r}")
 
 
 def _render_config_response(
@@ -170,8 +134,7 @@ def _catalog_health_payload(prompts_base: Path | None) -> dict[str, object]:
     if prompts_base is None:
         raise ValueError("No prompt catalog directory configured (set TNH_PROMPT_DIR or config).")
     adapter = PromptsAdapter(prompts_base=prompts_base.expanduser())
-    adapter.list_all()
-    health = adapter.catalog_health()
+    health = adapter.scan_catalog_health()
     return {
         "errors": [issue.model_dump(mode="json") for issue in health.errors],
         "warnings": [issue.model_dump(mode="json") for issue in health.warnings],

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/config.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/config.py
@@ -30,6 +30,7 @@ from tnh_scholar.cli_tools.tnh_gen.types import (
     ConfigUpdatePayload,
     ConfigValuePayload,
 )
+from tnh_scholar.gen_ai_service.pattern_catalog.adapters.prompts_adapter import PromptsAdapter
 
 app = typer.Typer(help="Inspect and edit tnh-gen configuration.")
 
@@ -78,12 +79,41 @@ def _format_config_text(overrides: ConfigData) -> str:
 
 
 def _build_config_data_entry(key: ConfigKey, value: ConfigValue) -> ConfigData:
-    return cast(ConfigData, {key: value})
+    match key:
+        case "prompt_catalog_dir":
+            return {"prompt_catalog_dir": value}
+        case "default_model":
+            return {"default_model": value}
+        case "max_dollars":
+            return {"max_dollars": value}
+        case "max_input_chars":
+            return {"max_input_chars": value}
+        case "default_temperature":
+            return {"default_temperature": value}
+        case "api_key":
+            return {"api_key": value}
+        case "cli_path":
+            return {"cli_path": value}
 
 
 def _build_config_value_payload(key: ConfigKey, value: ConfigValue, trace_id: str) -> ConfigValuePayload:
-    payload: dict[str, object] = {"trace_id": trace_id, key: value}
-    return cast(ConfigValuePayload, payload)
+    payload: ConfigValuePayload = {"trace_id": trace_id}
+    match key:
+        case "prompt_catalog_dir":
+            payload["prompt_catalog_dir"] = value
+        case "default_model":
+            payload["default_model"] = value
+        case "max_dollars":
+            payload["max_dollars"] = value
+        case "max_input_chars":
+            payload["max_input_chars"] = value
+        case "default_temperature":
+            payload["default_temperature"] = value
+        case "api_key":
+            payload["api_key"] = value
+        case "cli_path":
+            payload["cli_path"] = value
+    return payload
 
 
 def _build_config_update(key: ConfigKey, value: str | float | int) -> ConfigData:
@@ -91,7 +121,21 @@ def _build_config_update(key: ConfigKey, value: str | float | int) -> ConfigData
 
 
 def _get_config_value(config: ConfigData, key: ConfigKey) -> ConfigValue:
-    return cast(ConfigValue, config.get(key))
+    match key:
+        case "prompt_catalog_dir":
+            return config.get("prompt_catalog_dir")
+        case "default_model":
+            return config.get("default_model")
+        case "max_dollars":
+            return config.get("max_dollars")
+        case "max_input_chars":
+            return config.get("max_input_chars")
+        case "default_temperature":
+            return config.get("default_temperature")
+        case "api_key":
+            return config.get("api_key")
+        case "cli_path":
+            return config.get("cli_path")
 
 
 def _render_config_response(
@@ -119,6 +163,29 @@ def _render_config_response(
 
 
 def _render_show_config(trace_id: str, format_override: OutputFormat | None) -> str:
+    return _render_show_config_with_health(trace_id, format_override, catalog_health=False)
+
+
+def _catalog_health_payload(prompts_base: Path | None) -> dict[str, object]:
+    if prompts_base is None:
+        raise ValueError("No prompt catalog directory configured (set TNH_PROMPT_DIR or config).")
+    adapter = PromptsAdapter(prompts_base=prompts_base.expanduser())
+    adapter.list_all()
+    health = adapter.catalog_health()
+    return {
+        "errors": [issue.model_dump(mode="json") for issue in health.errors],
+        "warnings": [issue.model_dump(mode="json") for issue in health.warnings],
+        "error_count": health.error_count,
+        "warning_count": health.warning_count,
+    }
+
+
+def _render_show_config_with_health(
+    trace_id: str,
+    format_override: OutputFormat | None,
+    *,
+    catalog_health: bool,
+) -> str:
     config, meta = load_config(ctx.config_path)
     config_dump = cast(ConfigData, config.model_dump(mode="json"))
     api_payload: ConfigShowPayload = {
@@ -128,10 +195,18 @@ def _render_show_config(trace_id: str, format_override: OutputFormat | None) -> 
         "trace_id": trace_id,
     }
     overrides = load_config_overrides(ctx.config_path)
+    human_payload: object = overrides
+    text_fallback = _format_config_text(overrides)
+    if catalog_health:
+        health_payload = _catalog_health_payload(config.prompt_catalog_dir)
+        api_payload["catalog_health"] = health_payload
+        api_payload["catalog_errors"] = health_payload["error_count"]
+        human_payload = api_payload
+        text_fallback = None
     return _render_config_response(
         api_payload=cast(Mapping[str, object], api_payload),
-        human_payload=overrides,
-        text_fallback=_format_config_text(overrides),
+        human_payload=human_payload,
+        text_fallback=text_fallback,
         format_override=format_override,
     )
 
@@ -188,6 +263,11 @@ def _render_config_keys(keys: list[str], trace_id: str) -> str:
 
 @app.command("show")
 def show_config(
+    catalog_health: bool = typer.Option(
+        False,
+        "--catalog-health",
+        help="Include aggregated prompt catalog health in the response.",
+    ),
     format: OutputFormat | None = typer.Option(
         None,
         "--format",
@@ -202,7 +282,7 @@ def show_config(
     """
     trace_id = uuid4().hex
     try:
-        typer.echo(_render_show_config(trace_id, format))
+        typer.echo(_render_show_config_with_health(trace_id, format, catalog_health=catalog_health))
     except Exception as exc:  # noqa: BLE001
         exit_with_error(exc, trace_id=trace_id, format_override=format)
 

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/list.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/list.py
@@ -17,7 +17,7 @@ from tnh_scholar.cli_tools.tnh_gen.types import (
     ListHumanPayload,
 )
 from tnh_scholar.gen_ai_service.pattern_catalog.adapters.prompts_adapter import PromptsAdapter
-from tnh_scholar.prompt_system.domain.models import PromptMetadata
+from tnh_scholar.prompt_system.domain.models import CatalogHealth, PromptMetadata
 
 app = typer.Typer(help="List available prompts with metadata.", invoke_without_command=True)
 
@@ -90,8 +90,12 @@ def _build_entries(prompts: Iterable[PromptMetadata]) -> list[dict[str, object]]
     return [_normalize_prompt(prompt) for prompt in prompts]
 
 
-def _to_api_payload(entries: list[dict[str, object]], sources: list[str]) -> ListApiPayload:
-    return {
+def _to_api_payload(
+    entries: list[dict[str, object]],
+    sources: list[str],
+    catalog_health: CatalogHealth,
+) -> ListApiPayload:
+    payload: ListApiPayload = {
         "prompts": [
             {
                 "key": cast(str, entry["key"]),
@@ -111,6 +115,9 @@ def _to_api_payload(entries: list[dict[str, object]], sources: list[str]) -> Lis
         "count": len(entries),
         "sources": sources,
     }
+    if catalog_health.error_count > 0:
+        payload["catalog_errors"] = catalog_health.error_count
+    return payload
 
 
 def _to_human_payload(entries: list[dict[str, object]]) -> ListHumanPayload:
@@ -133,22 +140,22 @@ def _to_human_payload(entries: list[dict[str, object]]) -> ListHumanPayload:
     }
 
 
-def _emit_prompt_warnings(prompts: Iterable[PromptMetadata]) -> None:
-    """Emit warning hints to stderr for prompts missing proper frontmatter."""
-    if ctx.quiet:
+def _emit_catalog_health_summary(catalog_health: CatalogHealth) -> None:
+    """Emit a single fatal catalog-health summary in human mode."""
+    if ctx.quiet or ctx.api or catalog_health.error_count == 0:
         return
-    for prompt in prompts:
-        if getattr(prompt, "warnings", []):
-            typer.echo(
-                f"[warn] Prompt '{prompt.key}' missing/invalid frontmatter. {_EXPECTED_FRONTMATTER}",
-                err=True,
-            )
+    typer.echo(
+        f"[tnh-gen] {catalog_health.error_count} prompts failed to load. "
+        "Run 'tnh-gen config show --catalog-health' for details.",
+        err=True,
+    )
 
 
 def _render_list(
     *,
     prompts: list[PromptMetadata],
     sources: list[str],
+    catalog_health: CatalogHealth,
     fmt: ListOutputFormat,
     api: bool,
     keys_only: bool,
@@ -175,7 +182,7 @@ def _render_list(
         typer.echo(format_table(headers, rows))
         return
 
-    payload = _to_api_payload(entries, sources) if api else _to_human_payload(entries)
+    payload = _to_api_payload(entries, sources, catalog_health) if api else _to_human_payload(entries)
     typer.echo(render_output(payload, fmt))
 
 
@@ -203,12 +210,13 @@ def _list_prompts_impl(
     config, meta = load_config(ctx.config_path)
     adapter = _build_adapter(config.prompt_catalog_dir)
     prompts = list(_apply_filters(adapter.list_all(), tag, search))
-
-    _emit_prompt_warnings(prompts)
+    catalog_health = adapter.catalog_health()
+    _emit_catalog_health_summary(catalog_health)
     if keys_only:
         _render_list(
             prompts=prompts,
             sources=meta["sources"],
+            catalog_health=catalog_health,
             fmt=ListOutputFormat.text,
             api=ctx.api,
             keys_only=True,
@@ -219,6 +227,7 @@ def _list_prompts_impl(
     _render_list(
         prompts=prompts,
         sources=meta["sources"],
+        catalog_health=catalog_health,
         fmt=fmt,
         api=ctx.api,
         keys_only=False,

--- a/src/tnh_scholar/cli_tools/tnh_gen/types.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/types.py
@@ -47,6 +47,8 @@ class ConfigShowPayload(TypedDict):
     config: ConfigData
     sources: list[str]
     config_files: list[str]
+    catalog_health: NotRequired[dict[str, object]]
+    catalog_errors: NotRequired[int]
     trace_id: str
 
 
@@ -121,6 +123,7 @@ class ListApiPayload(TypedDict):
     prompts: list[ListApiEntry]
     count: int
     sources: list[str]
+    catalog_errors: NotRequired[int]
 
 
 class RunUsagePayload(TypedDict):

--- a/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
@@ -28,7 +28,7 @@ from tnh_scholar.prompt_system.adapters.filesystem_catalog_adapter import (
 from tnh_scholar.prompt_system.config.policy import PromptRenderPolicy, ValidationPolicy
 from tnh_scholar.prompt_system.config.prompt_catalog_config import PromptCatalogConfig
 from tnh_scholar.prompt_system.config.settings import PromptSystemSettings
-from tnh_scholar.prompt_system.domain.models import Prompt, PromptMetadata, RenderParams
+from tnh_scholar.prompt_system.domain.models import CatalogHealth, Prompt, PromptMetadata, RenderParams
 from tnh_scholar.prompt_system.domain.protocols import (
     PromptCatalogPort,
     PromptRendererPort,
@@ -116,6 +116,10 @@ class PromptsAdapter:
         """Get detailed metadata for a prompt (ADR-VSC02 requirement for CLI/VS Code)."""
         prompt = self._catalog.get(prompt_key)
         return prompt.metadata
+
+    def catalog_health(self) -> CatalogHealth:
+        """Expose aggregated prompt catalog health."""
+        return self._catalog.catalog_health()
 
     # ---- Internals ----
 

--- a/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
@@ -121,6 +121,11 @@ class PromptsAdapter:
         """Expose aggregated prompt catalog health."""
         return self._catalog.catalog_health()
 
+    def scan_catalog_health(self) -> CatalogHealth:
+        """Rebuild and return catalog health from current prompt sources."""
+        _: list[PromptMetadata] = self.list_all()
+        return self._catalog.catalog_health()
+
     # ---- Internals ----
 
     def _build_fingerprint(

--- a/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import logging
-from collections.abc import Sequence
-
 from pydantic import ValidationError
 
 from ..config.prompt_catalog_config import PromptCatalogConfig
 from ..domain.models import (
+    CatalogHealth,
     Prompt,
     PromptMetadata,
     PromptOutputContract,
@@ -21,8 +19,6 @@ from ..transport.cache import CacheTransport, InMemoryCacheTransport
 from ..transport.filesystem import FilesystemTransport
 from ..transport.models import PromptFileRequest
 from .frontmatter_fallback import extract_best_effort_body
-
-logger = logging.getLogger(__name__)
 
 
 class FilesystemPromptCatalog(PromptCatalogPort):
@@ -46,6 +42,7 @@ class FilesystemPromptCatalog(PromptCatalogPort):
         self._loader = loader
         self._cache = cache or InMemoryCacheTransport(default_ttl_s=config.cache_ttl_s)
         self._transport = transport or FilesystemTransport(mapper)
+        self._health = CatalogHealth()
 
     def get(self, key: str) -> Prompt:
         cache_key = self._make_cache_key(key)
@@ -61,6 +58,7 @@ class FilesystemPromptCatalog(PromptCatalogPort):
         except (ValidationError, ValueError) as exc:
             body = self._best_effort_body(file_resp.content)
             fallback_metadata = self._fallback_metadata(key, reason=str(exc))
+            self._health.errors.append(self._loader.parse_error_issue(key, str(exc)))
             prompt = Prompt(
                 name=fallback_metadata.name,
                 version=fallback_metadata.version,
@@ -72,6 +70,7 @@ class FilesystemPromptCatalog(PromptCatalogPort):
             if self._config.validation_on_load:
                 validation = self._loader.validate(prompt)
                 if not validation.succeeded():
+                    self._health.errors.extend(self._loader.validation_issues(key, validation))
                     fallback_metadata = self._fallback_metadata(
                         key,
                         reason=f"Invalid prompt: {validation.errors}",
@@ -84,10 +83,14 @@ class FilesystemPromptCatalog(PromptCatalogPort):
                             update={"warnings": fallback_metadata.warnings}
                         ),
                     )
-            warnings = getattr(prompt.metadata, "warnings", []) or []
+                    warnings = list(fallback_metadata.warnings)
+                else:
+                    warnings = getattr(prompt.metadata, "warnings", []) or []
+            else:
+                warnings = getattr(prompt.metadata, "warnings", []) or []
 
         if warnings:
-            self._log_warnings(key, warnings)
+            self._health.warnings.extend(self._loader.warning_issues(key, warnings))
 
         self._cache.set(cache_key, prompt, ttl_s=self._config.cache_ttl_s)
         return prompt
@@ -125,7 +128,6 @@ class FilesystemPromptCatalog(PromptCatalogPort):
     def _best_effort_body(self, content: str) -> str:
         return extract_best_effort_body(content)
 
-    def _log_warnings(self, key: str, warnings: Sequence[str]) -> None:
-        """Surface prompt warnings to help with diagnostics."""
-        for warning in warnings:
-            logger.warning("Prompt '%s' warning: %s", key, warning)
+    def catalog_health(self) -> CatalogHealth:
+        """Return the accumulated catalog health report."""
+        return self._health.model_copy(deep=True)

--- a/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
@@ -94,13 +94,13 @@ class FilesystemPromptCatalog(PromptCatalogPort):
             )
             warnings = list(fallback_metadata.warnings)
         else:
-            warnings = self._validated_prompt_warnings(key, prompt, health)
+            warnings = self._apply_validation_warnings(key, prompt, health)
 
         if warnings:
             health.warnings.extend(self._loader.warning_issues(key, warnings))
         return prompt
 
-    def _validated_prompt_warnings(
+    def _apply_validation_warnings(
         self,
         key: str,
         prompt: Prompt,

--- a/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
@@ -52,13 +52,40 @@ class FilesystemPromptCatalog(PromptCatalogPort):
         file_path = self._mapper.to_file_request(key, self._config.repository_path)
         request = PromptFileRequest(path=file_path, commit_sha=None)
         file_resp = self._transport.read_file(request)
+        prompt = self._load_prompt_from_content(key, file_resp.content, health=self._health)
+        self._cache.set(cache_key, prompt, ttl_s=self._config.cache_ttl_s)
+        return prompt
+
+    def list(self) -> list[PromptMetadata]:
+        files = self._transport.list_files(self._config.repository_path, pattern="**/*.md")
+        health = CatalogHealth()
+        prompts = []
+        for path in files:
+            key = self._mapper.to_key_from_path(path, self._config.repository_path)
+            request = PromptFileRequest(
+                path=self._mapper.to_file_request(key, self._config.repository_path),
+                commit_sha=None,
+            )
+            file_resp = self._transport.read_file(request)
+            prompt = self._load_prompt_from_content(key, file_resp.content, health=health)
+            self._cache.set(self._make_cache_key(key), prompt, ttl_s=self._config.cache_ttl_s)
+            prompts.append(prompt)
+        self._health = health
+        return [p.metadata for p in prompts]
+
+    def _load_prompt_from_content(
+        self,
+        key: str,
+        content: str,
+        *,
+        health: CatalogHealth,
+    ) -> Prompt:
         try:
-            prompt = self._mapper.to_domain_prompt(file_resp.content, source_key=key)
-            warnings: list[str] = []
+            prompt = self._mapper.to_domain_prompt(content, source_key=key)
         except (ValidationError, ValueError) as exc:
-            body = self._best_effort_body(file_resp.content)
+            body = self._best_effort_body(content)
             fallback_metadata = self._fallback_metadata(key, reason=str(exc))
-            self._health.errors.append(self._loader.parse_error_issue(key, str(exc)))
+            health.errors.append(self._loader.parse_error_issue(key, str(exc)))
             prompt = Prompt(
                 name=fallback_metadata.name,
                 version=fallback_metadata.version,
@@ -67,42 +94,34 @@ class FilesystemPromptCatalog(PromptCatalogPort):
             )
             warnings = list(fallback_metadata.warnings)
         else:
-            if self._config.validation_on_load:
-                validation = self._loader.validate(prompt)
-                if not validation.succeeded():
-                    self._health.errors.extend(self._loader.validation_issues(key, validation))
-                    fallback_metadata = self._fallback_metadata(
-                        key,
-                        reason=f"Invalid prompt: {validation.errors}",
-                    )
-                    prompt = Prompt(
-                        name=fallback_metadata.name,
-                        version=fallback_metadata.version,
-                        template=prompt.template,
-                        metadata=prompt.metadata.model_copy(
-                            update={"warnings": fallback_metadata.warnings}
-                        ),
-                    )
-                    warnings = list(fallback_metadata.warnings)
-                else:
-                    warnings = getattr(prompt.metadata, "warnings", []) or []
-            else:
-                warnings = getattr(prompt.metadata, "warnings", []) or []
+            warnings = self._validated_prompt_warnings(key, prompt, health)
 
         if warnings:
-            self._health.warnings.extend(self._loader.warning_issues(key, warnings))
-
-        self._cache.set(cache_key, prompt, ttl_s=self._config.cache_ttl_s)
+            health.warnings.extend(self._loader.warning_issues(key, warnings))
         return prompt
 
-    def list(self) -> list[PromptMetadata]:
-        files = self._transport.list_files(self._config.repository_path, pattern="**/*.md")
-        prompts = []
-        for path in files:
-            key = self._mapper.to_key_from_path(path, self._config.repository_path)
-            prompt = self.get(key)
-            prompts.append(prompt)
-        return [p.metadata for p in prompts]
+    def _validated_prompt_warnings(
+        self,
+        key: str,
+        prompt: Prompt,
+        health: CatalogHealth,
+    ) -> list[str]:
+        if not self._config.validation_on_load:
+            return list(getattr(prompt.metadata, "warnings", []) or [])
+
+        validation = self._loader.validate(prompt)
+        if validation.succeeded():
+            return list(getattr(prompt.metadata, "warnings", []) or [])
+
+        health.errors.extend(self._loader.validation_issues(key, validation))
+        fallback_metadata = self._fallback_metadata(
+            key,
+            reason=f"Invalid prompt: {validation.errors}",
+        )
+        prompt.metadata = prompt.metadata.model_copy(
+            update={"warnings": fallback_metadata.warnings}
+        )
+        return list(fallback_metadata.warnings)
 
     def _make_cache_key(self, prompt_key: str) -> str:
         return f"{prompt_key}@filesystem"

--- a/src/tnh_scholar/prompt_system/adapters/git_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/git_catalog_adapter.py
@@ -1,13 +1,14 @@
 """Git-backed prompt catalog adapter."""
 
-import logging
-from collections.abc import Sequence
+from __future__ import annotations
+
 from pathlib import Path
 
 from pydantic import ValidationError
 
 from ..config.prompt_catalog_config import PromptCatalogConfig
 from ..domain.models import (
+    CatalogHealth,
     Prompt,
     PromptMetadata,
     PromptOutputContract,
@@ -20,8 +21,6 @@ from ..transport.cache import CacheTransport, InMemoryCacheTransport
 from ..transport.git_client import GitTransportClient
 from ..transport.models import PromptFileRequest
 from .frontmatter_fallback import extract_best_effort_body
-
-logger = logging.getLogger(__name__)
 
 
 class GitPromptCatalog(PromptCatalogPort):
@@ -45,6 +44,7 @@ class GitPromptCatalog(PromptCatalogPort):
         self._loader = loader
         self._cache = cache or InMemoryCacheTransport(default_ttl_s=config.cache_ttl_s)
         self._mapper = mapper or PromptMapper()
+        self._health = CatalogHealth()
 
     def get(self, key: str) -> Prompt:
         cache_key = self._make_cache_key(key)
@@ -56,7 +56,7 @@ class GitPromptCatalog(PromptCatalogPort):
         prompt, warnings = self._load_prompt_with_fallback(key, file_resp.content)
 
         if warnings:
-            self._log_warnings(key, warnings)
+            self._health.warnings.extend(self._loader.warning_issues(key, warnings))
 
         self._cache.set(cache_key, prompt, ttl_s=self._config.cache_ttl_s)
         return prompt
@@ -87,6 +87,7 @@ class GitPromptCatalog(PromptCatalogPort):
     ) -> tuple[Prompt, list[str]]:
         body = self._best_effort_body(content)
         fallback_metadata = self._fallback_metadata(key, reason=reason)
+        self._health.errors.append(self._loader.parse_error_issue(key, reason))
         prompt = Prompt(
             name=fallback_metadata.name,
             version=fallback_metadata.version,
@@ -103,6 +104,7 @@ class GitPromptCatalog(PromptCatalogPort):
         if validation.succeeded():
             return prompt, self._prompt_warnings(prompt)
 
+        self._health.errors.extend(self._loader.validation_issues(key, validation))
         fallback_metadata = self._fallback_metadata(
             key,
             reason=f"Invalid prompt: {validation.errors}",
@@ -136,12 +138,19 @@ class GitPromptCatalog(PromptCatalogPort):
             key = self._mapper.to_key_from_path(changed_path, self._config.repository_path)
             self._cache.invalidate(self._make_cache_key(key))
 
+    def catalog_health(self) -> CatalogHealth:
+        """Return the accumulated catalog health report."""
+        return self._health.model_copy(deep=True)
+
     def _make_cache_key(self, prompt_key: str) -> str:
         commit = self._transport.get_current_commit()
         return f"{prompt_key}@{commit[:8]}"
 
     def _fallback_metadata(self, key: str, *, reason: str) -> PromptMetadata:
-        warning = f"Missing or invalid frontmatter for prompt '{key}': {reason}. {self._EXPECTED_FRONTMATTER}"
+        warning = (
+            f"Missing or invalid frontmatter for prompt '{key}': {reason}. "
+            f"{self._EXPECTED_FRONTMATTER}"
+        )
         return PromptMetadata(
             prompt_id=key,
             key=key,
@@ -160,8 +169,3 @@ class GitPromptCatalog(PromptCatalogPort):
 
     def _best_effort_body(self, content: str) -> str:
         return extract_best_effort_body(content)
-
-    def _log_warnings(self, key: str, warnings: Sequence[str]) -> None:
-        """Surface prompt warnings to help with diagnostics."""
-        for warning in warnings:
-            logger.warning("Prompt '%s' warning: %s", key, warning)

--- a/src/tnh_scholar/prompt_system/adapters/git_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/git_catalog_adapter.py
@@ -53,11 +53,7 @@ class GitPromptCatalog(PromptCatalogPort):
 
         file_req = self._build_file_request(key)
         file_resp = self._transport.read_file_at_commit(file_req)
-        prompt, warnings = self._load_prompt_with_fallback(key, file_resp.content)
-
-        if warnings:
-            self._health.warnings.extend(self._loader.warning_issues(key, warnings))
-
+        prompt = self._load_prompt_from_content(key, file_resp.content, health=self._health)
         self._cache.set(cache_key, prompt, ttl_s=self._config.cache_ttl_s)
         return prompt
 
@@ -67,16 +63,21 @@ class GitPromptCatalog(PromptCatalogPort):
             commit_sha=None,
         )
 
-    def _load_prompt_with_fallback(
+    def _load_prompt_from_content(
         self,
         key: str,
         content: str,
-    ) -> tuple[Prompt, list[str]]:
+        *,
+        health: CatalogHealth,
+    ) -> Prompt:
         try:
             prompt = self._mapper.to_domain_prompt(content, source_key=key)
         except (ValidationError, ValueError) as exc:
-            return self._build_prompt_from_invalid_file(key, content, reason=str(exc))
-        return self._apply_loader_validation(key, prompt)
+            return self._build_prompt_from_invalid_file(key, content, reason=str(exc), health=health)
+        warnings = self._apply_loader_validation(key, prompt, health=health)
+        if warnings:
+            health.warnings.extend(self._loader.warning_issues(key, warnings))
+        return prompt
 
     def _build_prompt_from_invalid_file(
         self,
@@ -84,40 +85,41 @@ class GitPromptCatalog(PromptCatalogPort):
         content: str,
         *,
         reason: str,
-    ) -> tuple[Prompt, list[str]]:
+        health: CatalogHealth,
+    ) -> Prompt:
         body = self._best_effort_body(content)
         fallback_metadata = self._fallback_metadata(key, reason=reason)
-        self._health.errors.append(self._loader.parse_error_issue(key, reason))
+        health.errors.append(self._loader.parse_error_issue(key, reason))
         prompt = Prompt(
             name=fallback_metadata.name,
             version=fallback_metadata.version,
             template=body,
             metadata=fallback_metadata,
         )
-        return prompt, list(fallback_metadata.warnings)
+        health.warnings.extend(self._loader.warning_issues(key, list(fallback_metadata.warnings)))
+        return prompt
 
-    def _apply_loader_validation(self, key: str, prompt: Prompt) -> tuple[Prompt, list[str]]:
+    def _apply_loader_validation(
+        self,
+        key: str,
+        prompt: Prompt,
+        *,
+        health: CatalogHealth,
+    ) -> list[str]:
         if not (self._config.validation_on_load and self._loader is not None):
-            return prompt, self._prompt_warnings(prompt)
+            return self._prompt_warnings(prompt)
 
         validation = self._loader.validate(prompt)
         if validation.succeeded():
-            return prompt, self._prompt_warnings(prompt)
+            return self._prompt_warnings(prompt)
 
-        self._health.errors.extend(self._loader.validation_issues(key, validation))
+        health.errors.extend(self._loader.validation_issues(key, validation))
         fallback_metadata = self._fallback_metadata(
             key,
             reason=f"Invalid prompt: {validation.errors}",
         )
-        updated_prompt = Prompt(
-            name=fallback_metadata.name,
-            version=fallback_metadata.version,
-            template=prompt.template,
-            metadata=prompt.metadata.model_copy(
-                update={"warnings": fallback_metadata.warnings}
-            ),
-        )
-        return updated_prompt, list(fallback_metadata.warnings)
+        prompt.metadata = prompt.metadata.model_copy(update={"warnings": fallback_metadata.warnings})
+        return list(fallback_metadata.warnings)
 
     def _prompt_warnings(self, prompt: Prompt) -> list[str]:
         warnings = getattr(prompt.metadata, "warnings", []) or []
@@ -125,14 +127,21 @@ class GitPromptCatalog(PromptCatalogPort):
 
     def list(self) -> list[PromptMetadata]:
         files = self._transport.list_files(pattern="**/*.md")
+        health = CatalogHealth()
         prompts = []
         for path in files:
             key = self._mapper.to_key_from_path(path, self._config.repository_path)
-            prompts.append(self.get(key))
+            file_req = self._build_file_request(key)
+            file_resp = self._transport.read_file_at_commit(file_req)
+            prompt = self._load_prompt_from_content(key, file_resp.content, health=health)
+            self._cache.set(self._make_cache_key(key), prompt, ttl_s=self._config.cache_ttl_s)
+            prompts.append(prompt)
+        self._health = health
         return [p.metadata for p in prompts]
 
     def refresh(self) -> None:
         refresh_resp = self._transport.pull_latest()
+        self._health = CatalogHealth()
         for changed in refresh_resp.changed_files:
             changed_path = Path(changed)
             key = self._mapper.to_key_from_path(changed_path, self._config.repository_path)

--- a/src/tnh_scholar/prompt_system/domain/models.py
+++ b/src/tnh_scholar/prompt_system/domain/models.py
@@ -223,3 +223,36 @@ class PromptValidationResult(BaseModel):
 
     def succeeded(self) -> bool:
         return len(self.errors) == 0
+
+
+class CatalogIssueType(str, Enum):
+    """Catalog health issue classifications."""
+
+    FRONTMATTER_PARSE_ERROR = "frontmatter_parse_error"
+    VALIDATION_ERROR = "validation_error"
+    METADATA_WARNING = "metadata_warning"
+
+
+class CatalogIssue(BaseModel):
+    """Single prompt catalog health issue."""
+
+    prompt_key: str
+    issue_type: CatalogIssueType
+    message: str
+
+
+class CatalogHealth(BaseModel):
+    """Aggregated prompt catalog health report."""
+
+    errors: list[CatalogIssue] = Field(default_factory=list)
+    warnings: list[CatalogIssue] = Field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        """Return the number of fatal prompt issues."""
+        return len(self.errors)
+
+    @property
+    def warning_count(self) -> int:
+        """Return the number of non-fatal prompt issues."""
+        return len(self.warnings)

--- a/src/tnh_scholar/prompt_system/domain/protocols.py
+++ b/src/tnh_scholar/prompt_system/domain/protocols.py
@@ -2,7 +2,14 @@
 
 from typing import Protocol
 
-from .models import Prompt, PromptMetadata, PromptValidationResult, RenderedPrompt, RenderParams
+from .models import (
+    CatalogHealth,
+    Prompt,
+    PromptMetadata,
+    PromptValidationResult,
+    RenderedPrompt,
+    RenderParams,
+)
 
 
 class PromptCatalogPort(Protocol):
@@ -14,6 +21,10 @@ class PromptCatalogPort(Protocol):
 
     def list(self) -> list[PromptMetadata]:
         """List available prompts."""
+        ...
+
+    def catalog_health(self) -> CatalogHealth:
+        """Return aggregated catalog health information."""
         ...
 
 
@@ -35,4 +46,3 @@ class PromptValidatorPort(Protocol):
     def validate_render(self, prompt: Prompt, params: RenderParams) -> PromptValidationResult:
         """Validate render inputs against prompt requirements."""
         ...
-

--- a/src/tnh_scholar/prompt_system/service/loader.py
+++ b/src/tnh_scholar/prompt_system/service/loader.py
@@ -1,6 +1,13 @@
 """Prompt loader orchestration service."""
 
-from ..domain.models import Prompt, PromptValidationResult
+from collections.abc import Sequence
+
+from ..domain.models import (
+    CatalogIssue,
+    CatalogIssueType,
+    Prompt,
+    PromptValidationResult,
+)
 from ..domain.protocols import PromptValidatorPort
 
 
@@ -13,3 +20,37 @@ class PromptLoader:
     def validate(self, prompt: Prompt) -> PromptValidationResult:
         """Validate prompt using configured validator."""
         return self._validator.validate(prompt)
+
+    def warning_issues(self, prompt_key: str, warnings: Sequence[str]) -> list[CatalogIssue]:
+        """Convert non-fatal prompt warnings into catalog issues."""
+        return [
+            CatalogIssue(
+                prompt_key=prompt_key,
+                issue_type=CatalogIssueType.METADATA_WARNING,
+                message=warning,
+            )
+            for warning in warnings
+        ]
+
+    def validation_issues(
+        self,
+        prompt_key: str,
+        validation: PromptValidationResult,
+    ) -> list[CatalogIssue]:
+        """Convert validation errors into fatal catalog issues."""
+        return [
+            CatalogIssue(
+                prompt_key=prompt_key,
+                issue_type=CatalogIssueType.VALIDATION_ERROR,
+                message=issue.message,
+            )
+            for issue in validation.errors
+        ]
+
+    def parse_error_issue(self, prompt_key: str, message: str) -> CatalogIssue:
+        """Build a fatal issue for unreadable or invalid frontmatter."""
+        return CatalogIssue(
+            prompt_key=prompt_key,
+            issue_type=CatalogIssueType.FRONTMATTER_PARSE_ERROR,
+            message=message,
+        )

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -7,18 +7,18 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-from typer.testing import CliRunner
 import yaml
+from typer.testing import CliRunner
 
 from tnh_scholar.cli_tools.tnh_gen import tnh_gen
 from tnh_scholar.cli_tools.tnh_gen.commands import run as run_module
-from tnh_scholar.cli_tools.tnh_gen.errors import ExitCode
 from tnh_scholar.cli_tools.tnh_gen.config_loader import CLIConfig
+from tnh_scholar.cli_tools.tnh_gen.errors import ExitCode
 from tnh_scholar.cli_tools.tnh_gen.state import ctx as cli_ctx
 from tnh_scholar.gen_ai_service.models.domain import (
     AdapterDiagnostics,
-    CompletionFailure,
     CompletionEnvelope,
+    CompletionFailure,
     CompletionOutcomeStatus,
     CompletionResult,
     FailureReason,
@@ -26,8 +26,8 @@ from tnh_scholar.gen_ai_service.models.domain import (
     Provenance,
     Usage,
 )
-from tnh_scholar.gen_ai_service.pattern_catalog.adapters.prompts_adapter import PromptsAdapter
 from tnh_scholar.gen_ai_service.models.errors import SafetyBlocked
+from tnh_scholar.gen_ai_service.pattern_catalog.adapters.prompts_adapter import PromptsAdapter
 from tnh_scholar.prompt_system.domain.models import PromptMetadata
 
 runner = CliRunner(mix_stderr=False)
@@ -197,7 +197,7 @@ def test_list_keys_only_emits_warning_for_legacy_prompt(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "legacy"
-    assert "[warn]" in result.stderr
+    assert "prompts failed to load" in result.stderr
 
 
 def test_list_includes_warning_for_legacy_prompt(tmp_path, monkeypatch):
@@ -216,7 +216,8 @@ def test_list_includes_warning_for_legacy_prompt(tmp_path, monkeypatch):
     assert "prompt" in warnings[0]
     assert "key" in warnings[0]
     assert "invalid-metadata" in payload["prompts"][0]["tags"]
-    assert "[warn]" in result.stderr
+    assert payload["catalog_errors"] == 1
+    assert result.stderr == ""
 
 
 def test_list_prompts_filters_by_tag_and_search(tmp_path, monkeypatch):
@@ -977,7 +978,7 @@ def test_run_api_failed_completion_returns_failure_payload_without_file(tmp_path
 
 
 def test_run_api_budget_block_returns_structured_payload(tmp_path, monkeypatch):
-    prompt_dir = _write_prompt(tmp_path)
+    _write_prompt(tmp_path)
     input_file = tmp_path / "input.txt"
     input_file.write_text("file-input", encoding="utf-8")
 
@@ -1024,7 +1025,7 @@ def test_run_api_budget_block_returns_structured_payload(tmp_path, monkeypatch):
 
 
 def test_run_human_budget_block_reports_actionable_text(tmp_path, monkeypatch):
-    prompt_dir = _write_prompt(tmp_path)
+    _write_prompt(tmp_path)
     input_file = tmp_path / "input.txt"
     input_file.write_text("file-input", encoding="utf-8")
 
@@ -1334,6 +1335,21 @@ def test_config_show_human_outputs_text(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "default_model: gpt-4o-mini" in result.stdout
+
+
+def test_config_show_catalog_health_outputs_report(tmp_path, monkeypatch):
+    prompt_dir = _write_legacy_prompt(tmp_path)
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+
+    result = runner.invoke(tnh_gen.app, ["--api", "config", "show", "--catalog-health"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["catalog_health"]["error_count"] == 1
+    assert payload["catalog_health"]["warning_count"] == 1
+    assert payload["catalog_health"]["errors"][0]["prompt_key"] == "legacy"
 
 
 def test_config_get_human_outputs_yaml(tmp_path, monkeypatch):

--- a/tests/prompt_system/test_catalog_adapters.py
+++ b/tests/prompt_system/test_catalog_adapters.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 from tnh_scholar.prompt_system.adapters.filesystem_catalog_adapter import (
@@ -97,8 +96,7 @@ def test_filesystem_catalog_get_accepts_immutable_reference(tmp_path: Path):
     assert prompt.metadata.canonical_key() == "agent-orch/planner/evaluate"
 
 
-def test_filesystem_catalog_falls_back_on_invalid_frontmatter(tmp_path: Path, caplog):
-    caplog.set_level(logging.WARNING)
+def test_filesystem_catalog_falls_back_on_invalid_frontmatter(tmp_path: Path):
     (tmp_path / "legacy.md").write_text(
         ("---\n# invalid frontmatter body\n---\nLegacy body\n"),
         encoding="utf-8",
@@ -113,7 +111,9 @@ def test_filesystem_catalog_falls_back_on_invalid_frontmatter(tmp_path: Path, ca
     assert prompt.metadata.version == "0.0.0-invalid"
     assert "legacy" in prompt.metadata.warnings[0]
     assert prompt.template == "Legacy body\n"
-    assert any("Prompt 'legacy' warning" in message for message in caplog.messages)
+    health = catalog.catalog_health()
+    assert health.error_count == 1
+    assert health.warning_count == 1
 
 
 def test_filesystem_catalog_falls_back_on_validation_errors(tmp_path: Path):
@@ -140,6 +140,9 @@ output_contract:
 
     assert prompt.template.strip() == "{{ result }}"
     assert any("Invalid prompt" in warning for warning in prompt.metadata.warnings)
+    health = catalog.catalog_health()
+    assert health.error_count == 1
+    assert health.warning_count == 1
 
 
 def test_filesystem_catalog_best_effort_body_without_frontmatter_block(tmp_path: Path):

--- a/tests/prompt_system/test_git_catalog.py
+++ b/tests/prompt_system/test_git_catalog.py
@@ -208,6 +208,9 @@ output_contract:
     assert prompt.metadata.version == "1"
     assert prompt.template.strip() == "{{ result }}"
     assert any("Invalid prompt" in warning for warning in prompt.metadata.warnings)
+    health = catalog.catalog_health()
+    assert health.error_count == 1
+    assert health.warning_count == 1
 
 
 def test_git_catalog_refresh_invalidates_changed_keys(tmp_path: Path, monkeypatch):

--- a/tests/prompt_system/test_git_catalog.py
+++ b/tests/prompt_system/test_git_catalog.py
@@ -255,3 +255,60 @@ def test_git_catalog_refresh_invalidates_changed_keys(tmp_path: Path, monkeypatc
 
     assert len(invalidated) == 1
     assert invalidated[0].startswith("agent-orch/planner/evaluate@")
+
+
+def test_git_catalog_refresh_clears_stale_catalog_health(tmp_path: Path, monkeypatch):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    _init_git_repo(repo_path)
+    (repo_path / "bad-json.md").write_text(
+        """---
+key: bad-json
+name: bad-json
+version: 1
+description: desc
+role: planner
+output_contract:
+  mode: json
+---
+{{ result }}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add invalid prompt"],
+        cwd=repo_path,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+    transport_config = GitTransportConfig(repository_path=repo_path, auto_pull=False)
+    mapper = PromptMapper()
+    validator = PromptValidator(ValidationPolicy())
+    loader = PromptLoader(validator)
+    transport = GitTransportClient(config=transport_config, mapper=mapper)
+    catalog_config = PromptCatalogConfig(repository_path=repo_path, enable_git_refresh=False)
+    catalog = GitPromptCatalog(
+        config=catalog_config,
+        transport=transport,
+        loader=loader,
+        mapper=mapper,
+    )
+
+    catalog.get("bad-json")
+    health = catalog.catalog_health()
+    assert health.error_count == 1
+    assert health.warning_count == 1
+
+    monkeypatch.setattr(
+        transport,
+        "pull_latest",
+        lambda: SimpleNamespace(changed_files=["bad-json.md"]),
+    )
+
+    catalog.refresh()
+
+    refreshed_health = catalog.catalog_health()
+    assert refreshed_health.error_count == 0
+    assert refreshed_health.warning_count == 0


### PR DESCRIPTION
## Summary
- aggregate prompt catalog health across filesystem and git adapters
- surface catalog load failures through `tnh-gen list` and `tnh-gen config show --catalog-health`
- add focused CLI and prompt-system regression coverage for catalog health reporting

## Validation
- `PYTHONPATH=/Users/phapman/Desktop/Projects/tnh-scholar-tnh-gen-pr2 /Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/pytest tests/prompt_system/test_catalog_adapters.py tests/prompt_system/test_git_catalog.py tests/cli_tools/test_tnh_gen.py -q`
- `PYTHONPATH=/Users/phapman/Desktop/Projects/tnh-scholar-tnh-gen-pr2 /Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/ruff check src/tnh_scholar/cli_tools/tnh_gen/commands/config.py src/tnh_scholar/cli_tools/tnh_gen/commands/list.py src/tnh_scholar/cli_tools/tnh_gen/types.py src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py src/tnh_scholar/prompt_system/adapters/git_catalog_adapter.py src/tnh_scholar/prompt_system/domain/models.py src/tnh_scholar/prompt_system/domain/protocols.py src/tnh_scholar/prompt_system/service/loader.py tests/cli_tools/test_tnh_gen.py tests/prompt_system/test_catalog_adapters.py tests/prompt_system/test_git_catalog.py`
- `PYTHONPATH=/Users/phapman/Desktop/Projects/tnh-scholar-tnh-gen-pr2 /Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/python scripts/pr_readiness.py --base origin/main`

## Notes
- `make pr-check` hits a Poetry interpreter-shim issue in secondary worktrees, so the equivalent readiness script was run directly via the repo `.venv`.
- Local Sourcery CLI review is not available in this environment tier; the PR stays within the preferred diff budget (`diff-chars: 34468`).

## Summary by Sourcery

Add aggregated prompt catalog health reporting and surface it through the tnh-gen CLI and catalog adapters.

New Features:
- Expose catalog health via new typed models aggregated by filesystem and git prompt catalog adapters.
- Add catalog health reporting to `tnh-gen list` and to `tnh-gen config show` via a new `--catalog-health` option, including API fields for catalog error counts.

Enhancements:
- Refine configuration payload handling in the tnh-gen config command for safer key-specific construction.
- Update prompt catalog loader to translate validation and parsing outcomes into structured catalog issues instead of log-based warnings.

Documentation:
- Update changelog and TODO roadmap to document the new catalog health/config reporting and progress on prompt catalog safety.

Tests:
- Expand CLI and prompt-system tests to cover catalog health accumulation, CLI summaries, and new config/catalog-health behavior.