### PR TITLE
[codex] add tnh-conductor status watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tnh-conductor status --watch` Live Monitoring** (2026-04-21)
+  - Added `--watch` and `--poll-interval-seconds` to `tnh-conductor status` so operators can stream machine-readable JSON status snapshots until a run reaches a terminal lifecycle state
+  - Preserved the existing one-shot status output when watch mode is not enabled
+  - Added focused CLI regression coverage for repeated polling through completion and immediate stop on blocked runs
+  - Files: `src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py`, `tests/cli_tools/test_tnh_conductor.py`
+
 - **SPIKE-10 Agent Coordination Comparison Result** (2026-04-20)
   - Recorded the five-arm SPIKE-10 result note for the shared `tnh-conductor status --watch` task across direct Codex, native subagents, explicit `codex-assistant`, explicit `claude-assistant`, and the maintained `tnh-conductor` path
   - Captured the main recommendation to keep `tnh-conductor` as the primary coordination substrate while treating direct Codex as the baseline and the assistant CLIs as experimental worker seams

--- a/TODO.md
+++ b/TODO.md
@@ -125,6 +125,7 @@ This section organizes work into three priority levels based on criticality for 
 - **Recent related docs work**:
   - documented the current low-noise Codex headless path, native subagent confirmation, and first supervisory shell-trial findings in `/docs/architecture/agent-orchestration/notes/experiments/` and `/docs/architecture/agent-orchestration/supervisory-shell-trial/`
   - SPIKE-10 comparison result now records the current practical recommendation: keep `tnh-conductor` as the main coordination substrate, harden native subagent launch reliability, and treat `codex-assistant` / `claude-assistant` worker paths as experimental until runtime bootstrap and auth are dependable
+  - direct-vs-conductor follow-up review selected the direct-arm `tnh-conductor status --watch` implementation as the merge candidate while preserving the maintained conductor run as the bootstrap-viability proof
 - **Recommended PR sizing**:
   - Prefer **2 PRs** to stay comfortably under diff-size guidance
   - A single PR is possible only if the implementation stays narrow and avoids CLI/app-layer work

--- a/docs/architecture/agent-orchestration/notes/experiments/spike-10-agent-coordination-comparison-result.md
+++ b/docs/architecture/agent-orchestration/notes/experiments/spike-10-agent-coordination-comparison-result.md
@@ -287,6 +287,13 @@ Existing agent-orch was best on control surface.
 
 That is the main reason to keep investing in it even though the direct arm remains cleaner on a small task.
 
+### Follow-up code comparison:
+
+- the direct arm and the `tnh-conductor` implementation arm both used the same Codex CLI execution family (`codex exec --ephemeral`)
+- the code quality of the direct arm had minor but noticeable quality edges in implementation. 
+- the small code-quality edge for the direct arm therefore looks more like a prompt and entrypoint-context difference than a runner-surface difference
+- in practice, that points to workflow prompt packaging and worker context as the next hardening opportunity for `tnh-conductor`
+
 ## What This Says About `tnh-gen`
 
 This comparison should not be read as evidence against using `tnh-gen`.

--- a/project_directory_tree.txt
+++ b/project_directory_tree.txt
@@ -86,6 +86,7 @@
 │   │   │   │   │   ├── index.md
 │   │   │   │   │   ├── oa01x-cloud-direction-generation-comparison-result.md
 │   │   │   │   │   ├── oa01x-spike-experiment-register.md
+│   │   │   │   │   ├── run-spike-10-agent-coordination-comparison.md
 │   │   │   │   │   ├── spike-02-execution-context-comparison.md
 │   │   │   │   │   ├── spike-03-native-subagent-smoke-test.md
 │   │   │   │   │   ├── spike-04-narrow-supervisory-comparison.md
@@ -94,6 +95,10 @@
 │   │   │   │   │   ├── spike-07-codex-home-state-dependency.md
 │   │   │   │   │   ├── spike-08-launch-context-env-contamination.md
 │   │   │   │   │   ├── spike-09-prompt-dir-three-arm-comparison.md
+│   │   │   │   │   ├── spike-10-agent-coordination-comparison-plan.md
+│   │   │   │   │   ├── spike-10-agent-coordination-comparison-result.md
+│   │   │   │   │   ├── spike-10-conductor-watch-task-brief.md
+│   │   │   │   │   ├── spike-10-conductor-watch.workflow.yaml
 │   │   │   │   │   └── spike-testing-sequence.md
 │   │   │   │   ├── index.md
 │   │   │   │   ├── plans
@@ -243,6 +248,7 @@
 │   │   │   │   ├── adr-tg01-cli-architecture.md
 │   │   │   │   ├── adr-tg01.1-human-friendly-defaults.md
 │   │   │   │   ├── adr-tg02-prompt-integration.md
+│   │   │   │   ├── adr-tg03-completion-contract.md
 │   │   │   │   └── index.md
 │   │   │   ├── design
 │   │   │   │   └── archive
@@ -252,6 +258,7 @@
 │   │   │   ├── index.md
 │   │   │   └── notes
 │   │   │       ├── index.md
+│   │   │       ├── tnh-gen-implementation-plan-2026-04.md
 │   │   │       └── tnh-gen-robustness-review-2026-04.md
 │   │   ├── transcription
 │   │   │   ├── adr
@@ -786,6 +793,12 @@
 │       │   │   ├── transcription_pipeline.py
 │       │   │   ├── validate.py
 │       │   │   └── version_check.py
+│       │   ├── claude_assistant
+│       │   │   ├── __init__.py
+│       │   │   └── claude_assistant.py
+│       │   ├── codex_assistant
+│       │   │   ├── __init__.py
+│       │   │   └── codex_assistant.py
 │       │   ├── json_to_srt
 │       │   │   ├── __init__.py
 │       │   │   ├── json_to_srt.py
@@ -1061,6 +1074,8 @@
 │   │       └── test_transcription_service_factory.py
 │   ├── cli_tools
 │   │   ├── test_audio_transcribe_pipeline.py
+│   │   ├── test_claude_assistant.py
+│   │   ├── test_codex_assistant.py
 │   │   ├── test_other_clis.py
 │   │   ├── test_tnh_conductor.py
 │   │   ├── test_tnh_gen.py
@@ -1081,6 +1096,8 @@
 │   │   │       ├── __init__.py
 │   │   │       └── test_jsonc_parser.py
 │   │   ├── test_completion_mapper.py
+│   │   ├── test_openai_adapter.py
+│   │   ├── test_openai_client.py
 │   │   ├── test_policy_routing_safety.py
 │   │   ├── test_registry_loader.py
 │   │   ├── test_registry_staleness.py
@@ -1154,4 +1171,4 @@
         │       └── path_utils.ts
         └── tsconfig.json
 
-242 directories, 913 files
+244 directories, 928 files

--- a/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
+++ b/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 import typer
+from pydantic import ValidationError
 
 from tnh_scholar.agent_orchestration.app import (
     HeadlessBootstrapConfig,
@@ -197,8 +198,26 @@ def _watch_status(
         RunLifecycleState.failed,
         RunLifecycleState.blocked,
     }
+    transient_status_read_errors = (OSError, ValueError, ValidationError)
+    max_read_attempts = 3
+    retry_interval_seconds = min(poll_interval_seconds, 0.1)
     while True:
-        status = _read_status_or_exit(run_id, resolved_runs_root)
+        status_path = STATUS_STORE.status_path_for_run(run_id, resolved_runs_root)
+        if not status_path.exists():
+            typer.echo(
+                f"Run status not found for '{run_id}' at {status_path}.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        for attempt_index in range(max_read_attempts):
+            try:
+                status = STATUS_STORE.read_status(run_id, resolved_runs_root)
+                break
+            except transient_status_read_errors as error:
+                if attempt_index == max_read_attempts - 1:
+                    typer.echo(f"Failed to read run status for '{run_id}': {error}", err=True)
+                    raise typer.Exit(code=1) from error
+                time.sleep(retry_interval_seconds * (attempt_index + 1))
         typer.echo(status.model_dump_json())
         if status.lifecycle_state in terminal_lifecycle_states:
             return

--- a/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
+++ b/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
@@ -155,10 +155,12 @@ def status_command(
     resolved_repo_root = repo_root.resolve()
     default_storage = HeadlessStorageConfig.for_repo_root(resolved_repo_root)
     resolved_runs_root = default_storage.runs_root if runs_root is None else runs_root
-    _validate_poll_interval(poll_interval_seconds)
-    _assert_status_exists(run_id, resolved_runs_root)
+    if watch and poll_interval_seconds <= 0:
+        typer.echo("Poll interval must be greater than 0 seconds.", err=True)
+        raise typer.Exit(code=1)
     if not watch:
-        _emit_status_snapshot(_read_status_or_exit(run_id, resolved_runs_root))
+        status = _read_status_or_exit(run_id, resolved_runs_root)
+        typer.echo(status.model_dump_json())
         return
     _watch_status(
         run_id=run_id,
@@ -167,38 +169,20 @@ def status_command(
     )
 
 
-def _validate_poll_interval(poll_interval_seconds: float) -> None:
-    """Reject non-positive polling intervals."""
-    if poll_interval_seconds > 0:
-        return
-    typer.echo("Poll interval must be greater than 0 seconds.", err=True)
-    raise typer.Exit(code=1)
-
-
-def _assert_status_exists(run_id: str, resolved_runs_root: Path) -> None:
-    """Fail fast when the canonical status artifact does not exist."""
-    status_path = STATUS_STORE.status_path_for_run(run_id, resolved_runs_root)
-    if status_path.exists():
-        return
-    typer.echo(
-        f"Run status not found for '{run_id}' at {status_path}.",
-        err=True,
-    )
-    raise typer.Exit(code=1)
-
-
 def _read_status_or_exit(run_id: str, resolved_runs_root: Path) -> RunStatus:
     """Read one live status snapshot or exit with a stable CLI error."""
+    status_path = STATUS_STORE.status_path_for_run(run_id, resolved_runs_root)
+    if not status_path.exists():
+        typer.echo(
+            f"Run status not found for '{run_id}' at {status_path}.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     try:
         return STATUS_STORE.read_status(run_id, resolved_runs_root)
     except Exception as error:
         typer.echo(f"Failed to read run status for '{run_id}': {error}", err=True)
         raise typer.Exit(code=1) from error
-
-
-def _emit_status_snapshot(status: RunStatus) -> None:
-    """Print one machine-readable status snapshot."""
-    typer.echo(status.model_dump_json())
 
 
 def _watch_status(
@@ -208,21 +192,17 @@ def _watch_status(
     poll_interval_seconds: float,
 ) -> None:
     """Poll status until the run reaches a terminal lifecycle state."""
-    while True:
-        status = _read_status_or_exit(run_id, resolved_runs_root)
-        _emit_status_snapshot(status)
-        if _is_terminal_lifecycle_state(status.lifecycle_state):
-            return
-        time.sleep(poll_interval_seconds)
-
-
-def _is_terminal_lifecycle_state(lifecycle_state: RunLifecycleState) -> bool:
-    """Return whether a lifecycle state should stop watch mode."""
-    return lifecycle_state in (
+    terminal_lifecycle_states = {
         RunLifecycleState.completed,
         RunLifecycleState.failed,
         RunLifecycleState.blocked,
-    )
+    }
+    while True:
+        status = _read_status_or_exit(run_id, resolved_runs_root)
+        typer.echo(status.model_dump_json())
+        if status.lifecycle_state in terminal_lifecycle_states:
+            return
+        time.sleep(poll_interval_seconds)
 
 
 def main() -> None:

--- a/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
+++ b/src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import typer
@@ -14,7 +15,11 @@ from tnh_scholar.agent_orchestration.app import (
     HeadlessStorageConfig,
     build_bootstrap_runtime_profile,
 )
-from tnh_scholar.agent_orchestration.run_artifacts import FilesystemRunArtifactStore
+from tnh_scholar.agent_orchestration.run_artifacts import (
+    FilesystemRunArtifactStore,
+    RunLifecycleState,
+    RunStatus,
+)
 
 STATUS_STORE = FilesystemRunArtifactStore()
 
@@ -135,24 +140,89 @@ def status_command(
         resolve_path=True,
         help="Optional override for the canonical runs root.",
     ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        help="Poll and print status snapshots until the run reaches a terminal state.",
+    ),
+    poll_interval_seconds: float = typer.Option(
+        1.0,
+        "--poll-interval-seconds",
+        help="Polling interval in seconds when --watch is enabled.",
+    ),
 ) -> None:
     """Read the maintained live status artifact for one run."""
     resolved_repo_root = repo_root.resolve()
     default_storage = HeadlessStorageConfig.for_repo_root(resolved_repo_root)
     resolved_runs_root = default_storage.runs_root if runs_root is None else runs_root
+    _validate_poll_interval(poll_interval_seconds)
+    _assert_status_exists(run_id, resolved_runs_root)
+    if not watch:
+        _emit_status_snapshot(_read_status_or_exit(run_id, resolved_runs_root))
+        return
+    _watch_status(
+        run_id=run_id,
+        resolved_runs_root=resolved_runs_root,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+
+
+def _validate_poll_interval(poll_interval_seconds: float) -> None:
+    """Reject non-positive polling intervals."""
+    if poll_interval_seconds > 0:
+        return
+    typer.echo("Poll interval must be greater than 0 seconds.", err=True)
+    raise typer.Exit(code=1)
+
+
+def _assert_status_exists(run_id: str, resolved_runs_root: Path) -> None:
+    """Fail fast when the canonical status artifact does not exist."""
     status_path = STATUS_STORE.status_path_for_run(run_id, resolved_runs_root)
-    if not status_path.exists():
-        typer.echo(
-            f"Run status not found for '{run_id}' at {status_path}.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
+    if status_path.exists():
+        return
+    typer.echo(
+        f"Run status not found for '{run_id}' at {status_path}.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _read_status_or_exit(run_id: str, resolved_runs_root: Path) -> RunStatus:
+    """Read one live status snapshot or exit with a stable CLI error."""
     try:
-        status = STATUS_STORE.read_status(run_id, resolved_runs_root)
+        return STATUS_STORE.read_status(run_id, resolved_runs_root)
     except Exception as error:
         typer.echo(f"Failed to read run status for '{run_id}': {error}", err=True)
         raise typer.Exit(code=1) from error
+
+
+def _emit_status_snapshot(status: RunStatus) -> None:
+    """Print one machine-readable status snapshot."""
     typer.echo(status.model_dump_json())
+
+
+def _watch_status(
+    *,
+    run_id: str,
+    resolved_runs_root: Path,
+    poll_interval_seconds: float,
+) -> None:
+    """Poll status until the run reaches a terminal lifecycle state."""
+    while True:
+        status = _read_status_or_exit(run_id, resolved_runs_root)
+        _emit_status_snapshot(status)
+        if _is_terminal_lifecycle_state(status.lifecycle_state):
+            return
+        time.sleep(poll_interval_seconds)
+
+
+def _is_terminal_lifecycle_state(lifecycle_state: RunLifecycleState) -> bool:
+    """Return whether a lifecycle state should stop watch mode."""
+    return lifecycle_state in (
+        RunLifecycleState.completed,
+        RunLifecycleState.failed,
+        RunLifecycleState.blocked,
+    )
 
 
 def main() -> None:

--- a/src_directory_tree.txt
+++ b/src_directory_tree.txt
@@ -208,6 +208,12 @@
     │   │   ├── transcription_pipeline.py
     │   │   ├── validate.py
     │   │   └── version_check.py
+    │   ├── claude_assistant
+    │   │   ├── __init__.py
+    │   │   └── claude_assistant.py
+    │   ├── codex_assistant
+    │   │   ├── __init__.py
+    │   │   └── codex_assistant.py
     │   ├── json_to_srt
     │   │   ├── __init__.py
     │   │   ├── json_to_srt.py
@@ -449,4 +455,4 @@
         ├── extract_tags.py
         └── xml_processing.py
 
-97 directories, 353 files
+99 directories, 357 files

--- a/tests/cli_tools/test_tnh_conductor.py
+++ b/tests/cli_tools/test_tnh_conductor.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
 
 from typer.testing import CliRunner
 
+from tnh_scholar.agent_orchestration.kernel.enums import Opcode
+from tnh_scholar.agent_orchestration.run_artifacts import RunLifecycleState, RunStatus
 from tnh_scholar.cli_tools.tnh_conductor import tnh_conductor
 
 runner = CliRunner(mix_stderr=False)
@@ -221,3 +225,190 @@ def test_tnh_conductor_status_fails_for_missing_run(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Run status not found" in result.stderr
+
+
+def test_tnh_conductor_status_watch_outputs_jsonl_until_completed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    runs_root = tmp_path / "runs"
+    run_id = "watch-run"
+    paths = tnh_conductor.STATUS_STORE.create_run(run_id, runs_root)
+
+    emitted_statuses = iter(
+        (
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.running,
+                updated_second=1,
+            ),
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.waiting,
+                updated_second=2,
+            ),
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.completed,
+                updated_second=3,
+            ),
+        )
+    )
+    sleep_calls: list[float] = []
+    tnh_conductor.STATUS_STORE.write_status(
+        _build_status(
+            run_id=run_id,
+            workflow_id="watch-workflow",
+            lifecycle_state=RunLifecycleState.running,
+            updated_second=0,
+        ),
+        paths,
+    )
+
+    monkeypatch.setattr(
+        type(tnh_conductor.STATUS_STORE),
+        "read_status",
+        lambda _, requested_run_id, requested_root: _next_status(
+            emitted_statuses,
+            requested_run_id=requested_run_id,
+            requested_root=requested_root,
+            expected_run_id=run_id,
+            expected_root=runs_root,
+        ),
+    )
+    monkeypatch.setattr(tnh_conductor.time, "sleep", sleep_calls.append)
+
+    result = runner.invoke(
+        tnh_conductor.app,
+        [
+            "status",
+            run_id,
+            "--repo-root",
+            str(repo_root),
+            "--runs-root",
+            str(runs_root),
+            "--watch",
+            "--poll-interval-seconds",
+            "0.25",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [payload["lifecycle_state"] for payload in payloads] == [
+        RunLifecycleState.running.value,
+        RunLifecycleState.waiting.value,
+        RunLifecycleState.completed.value,
+    ]
+    assert sleep_calls == [0.25, 0.25]
+
+
+def test_tnh_conductor_status_watch_stops_when_blocked(monkeypatch, tmp_path: Path) -> None:
+    repo_root = _init_repo(tmp_path)
+    runs_root = tmp_path / "runs"
+    run_id = "blocked-run"
+    paths = tnh_conductor.STATUS_STORE.create_run(run_id, runs_root)
+
+    emitted_statuses = iter(
+        (
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.running,
+                updated_second=1,
+            ),
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.blocked,
+                updated_second=2,
+                blocking_reason="needs_human",
+            ),
+        )
+    )
+    sleep_calls: list[float] = []
+    tnh_conductor.STATUS_STORE.write_status(
+        _build_status(
+            run_id=run_id,
+            workflow_id="watch-workflow",
+            lifecycle_state=RunLifecycleState.running,
+            updated_second=0,
+        ),
+        paths,
+    )
+
+    monkeypatch.setattr(
+        type(tnh_conductor.STATUS_STORE),
+        "read_status",
+        lambda _, requested_run_id, requested_root: _next_status(
+            emitted_statuses,
+            requested_run_id=requested_run_id,
+            requested_root=requested_root,
+            expected_run_id=run_id,
+            expected_root=runs_root,
+        ),
+    )
+    monkeypatch.setattr(tnh_conductor.time, "sleep", sleep_calls.append)
+
+    result = runner.invoke(
+        tnh_conductor.app,
+        [
+            "status",
+            run_id,
+            "--repo-root",
+            str(repo_root),
+            "--runs-root",
+            str(runs_root),
+            "--watch",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [payload["lifecycle_state"] for payload in payloads] == [
+        RunLifecycleState.running.value,
+        RunLifecycleState.blocked.value,
+    ]
+    assert payloads[-1]["blocking_reason"] == "needs_human"
+    assert sleep_calls == [1.0]
+
+
+def _build_status(
+    *,
+    run_id: str,
+    workflow_id: str,
+    lifecycle_state: RunLifecycleState,
+    updated_second: int,
+    blocking_reason: str | None = None,
+) -> RunStatus:
+    """Build one typed CLI status snapshot fixture."""
+    return RunStatus(
+        run_id=run_id,
+        workflow_id=workflow_id,
+        started_at=datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 4, 20, 12, 0, updated_second, tzinfo=timezone.utc),
+        lifecycle_state=lifecycle_state,
+        current_step_id="implement",
+        last_completed_step_id="design",
+        active_opcode=Opcode.run_agent,
+        elapsed_seconds=updated_second,
+        blocking_reason=blocking_reason,
+    )
+
+
+def _next_status(
+    statuses: Iterator[RunStatus],
+    *,
+    requested_run_id: str,
+    requested_root: Path,
+    expected_run_id: str,
+    expected_root: Path,
+) -> RunStatus:
+    """Return the next mocked status and validate the CLI call contract."""
+    assert requested_run_id == expected_run_id
+    assert requested_root == expected_root
+    return next(statuses)

--- a/tests/cli_tools/test_tnh_conductor.py
+++ b/tests/cli_tools/test_tnh_conductor.py
@@ -377,6 +377,80 @@ def test_tnh_conductor_status_watch_stops_when_blocked(monkeypatch, tmp_path: Pa
     assert sleep_calls == [1.0]
 
 
+def test_tnh_conductor_status_watch_retries_transient_read_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    runs_root = tmp_path / "runs"
+    run_id = "retry-run"
+    paths = tnh_conductor.STATUS_STORE.create_run(run_id, runs_root)
+
+    emitted_statuses = iter(
+        (
+            ValueError("transient parse failure"),
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.running,
+                updated_second=1,
+            ),
+            _build_status(
+                run_id=run_id,
+                workflow_id="watch-workflow",
+                lifecycle_state=RunLifecycleState.completed,
+                updated_second=2,
+            ),
+        )
+    )
+    sleep_calls: list[float] = []
+    tnh_conductor.STATUS_STORE.write_status(
+        _build_status(
+            run_id=run_id,
+            workflow_id="watch-workflow",
+            lifecycle_state=RunLifecycleState.running,
+            updated_second=0,
+        ),
+        paths,
+    )
+
+    monkeypatch.setattr(
+        type(tnh_conductor.STATUS_STORE),
+        "read_status",
+        lambda _, requested_run_id, requested_root: _next_status_or_error(
+            emitted_statuses,
+            requested_run_id=requested_run_id,
+            requested_root=requested_root,
+            expected_run_id=run_id,
+            expected_root=runs_root,
+        ),
+    )
+    monkeypatch.setattr(tnh_conductor.time, "sleep", sleep_calls.append)
+
+    result = runner.invoke(
+        tnh_conductor.app,
+        [
+            "status",
+            run_id,
+            "--repo-root",
+            str(repo_root),
+            "--runs-root",
+            str(runs_root),
+            "--watch",
+            "--poll-interval-seconds",
+            "0.25",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [payload["lifecycle_state"] for payload in payloads] == [
+        RunLifecycleState.running.value,
+        RunLifecycleState.completed.value,
+    ]
+    assert sleep_calls == [0.1, 0.25]
+
+
 def _build_status(
     *,
     run_id: str,
@@ -412,3 +486,20 @@ def _next_status(
     assert requested_run_id == expected_run_id
     assert requested_root == expected_root
     return next(statuses)
+
+
+def _next_status_or_error(
+    statuses: Iterator[RunStatus | Exception],
+    *,
+    requested_run_id: str,
+    requested_root: Path,
+    expected_run_id: str,
+    expected_root: Path,
+) -> RunStatus:
+    """Return the next mocked status or raise one transient read error."""
+    assert requested_run_id == expected_run_id
+    assert requested_root == expected_root
+    next_item = next(statuses)
+    if isinstance(next_item, Exception):
+        raise next_item
+    return next_item


### PR DESCRIPTION
## Summary
Adds live watch support to `tnh-conductor status` so operators can stream machine-readable JSON snapshots until a run reaches a terminal lifecycle state.

## What Changed
- adds `--watch` and `--poll-interval-seconds` to `tnh-conductor status`
- preserves the existing one-shot JSON status output when watch mode is not enabled
- stops watch mode on terminal states including `completed`, `failed`, and `blocked`
- adds focused CLI regression coverage for repeated polling through completion and immediate stop on blocked runs
- records the SPIKE-10 follow-up note that the direct arm and maintained conductor arm used the same Codex CLI execution family, so the small quality gap appears to come from prompt/entrypoint framing rather than the runner surface

## Why
SPIKE-10 established that the maintained `tnh-conductor` path is bootstrap-viable. The direct-arm implementation was selected as the merge candidate for the bounded `status --watch` task after a follow-up quality review against the conductor-produced implementation.

## Validation
- `poetry run pytest tests/cli_tools/test_tnh_conductor.py -q`
- `poetry run ruff check src/tnh_scholar/cli_tools/tnh_conductor/ tests/cli_tools/test_tnh_conductor.py`
- `poetry run mypy src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py tests/cli_tools/test_tnh_conductor.py`
- `poetry run sourcery review src/tnh_scholar/cli_tools/tnh_conductor/tnh_conductor.py tests/cli_tools/test_tnh_conductor.py 2>&1`
- `make pr-check`
- `make ci-check`

## Notes
`make ci-check` completed successfully while also surfacing existing non-blocking repo-wide lint/type debt and informational docs/tree drift outside this change set.

## Summary by Sourcery

Add live watch mode to the `tnh-conductor status` CLI for streaming JSON status snapshots until runs reach terminal states and document the SPIKE-10 follow-up comparison outcome.

New Features:
- Introduce `--watch` and `--poll-interval-seconds` options to `tnh-conductor status` to support continuous polling and JSONL output of run status until completion, failure, or blocking.

Enhancements:
- Refactor status reading and emission into helper functions to support both one-shot and watch modes while preserving existing behavior.

Documentation:
- Extend SPIKE-10 experiment notes with follow-up findings comparing direct vs `tnh-conductor` implementations and their implications for future hardening.
- Update the changelog and TODO notes to record the new `tnh-conductor status --watch` capability and the outcome of the direct-vs-conductor review.

Tests:
- Add CLI tests covering status watch behavior, including repeated polling through completion and immediate termination on blocked runs.