### PR TITLE
fix: normalize audio-transcribe structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **audio-transcribe Structured Transcript Output Fix** (2026-04-21)
+  - Fixed the `audio-transcribe` CLI crash when the transcription pipeline returns structured transcript records instead of plain strings
+  - Normalized CLI output so transcript writes and stdout rendering accept both legacy string entries and the current dict-shaped pipeline results, while skipping failed chunks cleanly
+  - Added focused regression coverage for the structured transcript normalization path
+  - Files: `src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py`, `tests/cli_tools/test_audio_transcribe.py`
+
 - **Workflow and Release-Prep Documentation Clarification** (2026-04-21)
   - Clarified in `AGENTS.md` that normal PRs are the default workflow and that `git branch -D` is allowed only with explicit approval plus non-loss verification
   - Updated `TODO.md` release framing to mark the maintained `tnh-conductor` bootstrap path as a usable prototype and to put `0.4.0` release-prep cleanup first in the queue

--- a/TODO.md
+++ b/TODO.md
@@ -475,6 +475,18 @@ docs/architecture/jvb-viewer/adr/
   - [ ] Migrate CLI to Typer with minimal surface (smoke tests only)
   - [ ] Add service-layer tests for all audio-transcribe use cases
 
+#### 🚧 Fully Usable audio-transcribe Hardening Path (P2)
+
+- **Status**: NOT STARTED
+- **Goal**: Make `audio-transcribe` safe for routine real-world use by eliminating stack dumps from expected fault paths and hardening the tool against edge-case and provider-shape failures.
+- **Tasks**:
+  - [ ] Build a full-spectrum regression matrix covering local files, YouTube URLs, CSV input, diarization on/off, Whisper, and AssemblyAI
+  - [ ] Add end-to-end CLI regression coverage for normal runs plus representative operator workflows used in practice
+  - [ ] Add fault-injection coverage for provider shape drift, empty/partial transcript results, chunk-level failures, file-write failures, temp-dir cleanup failures, and missing dependency/runtime preconditions
+  - [ ] Ensure expected runtime faults exit with user-facing errors instead of Python tracebacks
+  - [ ] Capture and preserve real-world reproductions as named regression fixtures/cases whenever a live failure is found
+  - [ ] Run a post-hardening soak pass against representative real inputs before the next minor release
+
 #### ⏸️ Agent Orchestration - Codex Runner (ADR-OA03.2)
 
 - **Status**: TABLED (2026-01-25)

--- a/src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py
+++ b/src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py
@@ -35,6 +35,7 @@ import logging
 import tempfile
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 import click
 from dotenv import load_dotenv
@@ -128,9 +129,9 @@ class AudioTranscribeApp:
             transcription_options=self.transcription_options,
         )
         self._echo_settings()
-        transcripts: list[str] = pipeline.run()
-        self._write_transcript(transcripts)
-        self._print_transcripts(transcripts)
+        transcript_texts = _normalize_transcript_texts(pipeline.run())
+        self._write_transcript(transcript_texts)
+        self._print_transcripts(transcript_texts)
         self._cleanup_temp_dir()
 
     def _cleanup_temp_dir(self) -> None:
@@ -230,7 +231,7 @@ class AudioTranscribeApp:
         click.echo(f"Re-using existing downloaded audio file: {download_file}")
         return download_file
 
-    def _extract_yt_audio(self, dl, download_path):
+    def _extract_yt_audio(self, dl: Any, download_path: Path) -> Path:
         video_data = dl.get_audio(
                 self.yt_url,
                 start=self.start_time,
@@ -299,6 +300,47 @@ class AudioTranscribeApp:
         """
         for i, text in enumerate(transcripts, 1):
             print(f"\n--- Transcript chunk {i} ---\n{text}\n")
+
+
+def _normalize_transcript_texts(transcripts: list[Any] | None) -> list[str]:
+    """Normalize pipeline transcript output into printable text chunks."""
+    if transcripts is None:
+        raise RuntimeError("Transcription pipeline returned no transcript output.")
+
+    transcript_texts: list[str] = []
+    for transcript_entry in transcripts:
+        normalized_text = _normalize_transcript_entry(transcript_entry)
+        if normalized_text:
+            transcript_texts.append(normalized_text)
+    return transcript_texts
+
+
+def _normalize_transcript_entry(transcript_entry: Any) -> str | None:
+    """Convert one pipeline transcript entry into plain text for CLI output."""
+    if isinstance(transcript_entry, str):
+        return transcript_entry.strip() or None
+
+    if not isinstance(transcript_entry, dict):
+        entry_type = type(transcript_entry).__name__
+        raise TypeError(f"Unsupported transcript entry type: {entry_type}")
+
+    transcript_text = transcript_entry.get("transcript")
+    if transcript_text is None:
+        _log_failed_transcript_chunk(transcript_entry)
+        return None
+
+    if not isinstance(transcript_text, str):
+        entry_type = type(transcript_text).__name__
+        raise TypeError(f"Transcript text must be a string, got: {entry_type}")
+
+    return transcript_text.strip() or None
+
+
+def _log_failed_transcript_chunk(transcript_entry: dict[Any, Any]) -> None:
+    """Emit a warning when a transcript chunk failed upstream."""
+    error_detail = transcript_entry.get("error")
+    if error_detail:
+        logger.warning("Skipping failed transcript chunk: %s", error_detail)
 
 @click.command()
 @click.option(

--- a/src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py
+++ b/src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py
@@ -321,8 +321,8 @@ def _normalize_transcript_entry(transcript_entry: Any) -> str | None:
         return transcript_entry.strip() or None
 
     if not isinstance(transcript_entry, dict):
-        entry_type = type(transcript_entry).__name__
-        raise TypeError(f"Unsupported transcript entry type: {entry_type}")
+        _log_unsupported_transcript_entry(transcript_entry)
+        return None
 
     transcript_text = transcript_entry.get("transcript")
     if transcript_text is None:
@@ -330,8 +330,8 @@ def _normalize_transcript_entry(transcript_entry: Any) -> str | None:
         return None
 
     if not isinstance(transcript_text, str):
-        entry_type = type(transcript_text).__name__
-        raise TypeError(f"Transcript text must be a string, got: {entry_type}")
+        _log_invalid_transcript_text(transcript_text)
+        return None
 
     return transcript_text.strip() or None
 
@@ -341,6 +341,24 @@ def _log_failed_transcript_chunk(transcript_entry: dict[Any, Any]) -> None:
     error_detail = transcript_entry.get("error")
     if error_detail:
         logger.warning("Skipping failed transcript chunk: %s", error_detail)
+        return
+
+    logger.warning(
+        "Skipping failed transcript chunk without error details: %r",
+        transcript_entry,
+    )
+
+
+def _log_unsupported_transcript_entry(transcript_entry: Any) -> None:
+    """Emit a warning for malformed transcript entries."""
+    entry_type = type(transcript_entry).__name__
+    logger.warning("Skipping unsupported transcript entry type: %s", entry_type)
+
+
+def _log_invalid_transcript_text(transcript_text: Any) -> None:
+    """Emit a warning for malformed transcript text payloads."""
+    entry_type = type(transcript_text).__name__
+    logger.warning("Skipping transcript entry with non-string text: %s", entry_type)
 
 @click.command()
 @click.option(

--- a/tests/cli_tools/test_audio_transcribe.py
+++ b/tests/cli_tools/test_audio_transcribe.py
@@ -32,8 +32,37 @@ def test_normalize_transcript_texts_extracts_structured_entries(
     assert "Skipping failed transcript chunk: upstream timeout" in caplog.text
 
 
-def test_normalize_transcript_texts_rejects_non_string_transcript_values() -> None:
+def test_normalize_transcript_texts_warns_for_missing_error_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transcripts = [{"chunk": None, "transcript": None, "error": None}]
+
+    with caplog.at_level(logging.WARNING):
+        result = _normalize_transcript_texts(transcripts)
+
+    assert result == []
+    assert "Skipping failed transcript chunk without error details" in caplog.text
+
+
+def test_normalize_transcript_texts_warns_for_non_string_transcript_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     transcripts = [{"chunk": None, "transcript": 123, "error": None}]
 
-    with pytest.raises(TypeError, match="Transcript text must be a string"):
-        _normalize_transcript_texts(transcripts)
+    with caplog.at_level(logging.WARNING):
+        result = _normalize_transcript_texts(transcripts)
+
+    assert result == []
+    assert "Skipping transcript entry with non-string text: int" in caplog.text
+
+
+def test_normalize_transcript_texts_warns_for_unsupported_entries(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transcripts = [123]
+
+    with caplog.at_level(logging.WARNING):
+        result = _normalize_transcript_texts(transcripts)
+
+    assert result == []
+    assert "Skipping unsupported transcript entry type: int" in caplog.text

--- a/tests/cli_tools/test_audio_transcribe.py
+++ b/tests/cli_tools/test_audio_transcribe.py
@@ -1,0 +1,39 @@
+import logging
+
+import pytest
+
+from tnh_scholar.cli_tools.audio_transcribe.audio_transcribe import (
+    _normalize_transcript_texts,
+)
+
+
+def test_normalize_transcript_texts_accepts_string_entries() -> None:
+    transcripts = [" first chunk ", "second chunk"]
+
+    assert _normalize_transcript_texts(transcripts) == [
+        "first chunk",
+        "second chunk",
+    ]
+
+
+def test_normalize_transcript_texts_extracts_structured_entries(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transcripts = [
+        {"chunk": None, "transcript": " first chunk ", "error": None},
+        {"chunk": None, "transcript": None, "error": "upstream timeout"},
+        {"chunk": None, "transcript": "second chunk", "error": None},
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = _normalize_transcript_texts(transcripts)
+
+    assert result == ["first chunk", "second chunk"]
+    assert "Skipping failed transcript chunk: upstream timeout" in caplog.text
+
+
+def test_normalize_transcript_texts_rejects_non_string_transcript_values() -> None:
+    transcripts = [{"chunk": None, "transcript": 123, "error": None}]
+
+    with pytest.raises(TypeError, match="Transcript text must be a string"):
+        _normalize_transcript_texts(transcripts)


### PR DESCRIPTION
## What changed
- fixed `audio-transcribe` so the CLI no longer crashes when the transcription pipeline returns structured transcript records instead of plain strings
- normalized transcript output at the CLI boundary for both file writing and stdout rendering
- added focused regression coverage for structured transcript entries, skipped failed chunks, and invalid transcript payloads
- added an explicit TODO hardening track for making `audio-transcribe` fully usable under real-world fault conditions

## Why
A live run against a local mp3 completed diarization and transcription, then crashed while writing the output file because the CLI still assumed `list[str]` and called `.strip()` on a dict-shaped transcript entry.

## Impact
- fixes a real user-facing traceback in an actively used CLI
- keeps partial chunk failures from crashing transcript output rendering
- records the broader hardening path needed before the next minor release

## Root cause
`TranscriptionPipeline` already returns structured records shaped like `{chunk, transcript, error}`, but `audio_transcribe.py` still treated pipeline output as `list[str]` in `_write_transcript()` and `_print_transcripts()`.

## Validation
- `poetry run pytest tests/cli_tools/test_audio_transcribe.py tests/cli_tools/test_audio_transcribe_pipeline.py -q`
- `poetry run ruff check src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py tests/cli_tools/test_audio_transcribe.py tests/cli_tools/test_audio_transcribe_pipeline.py`
- `poetry run mypy src/tnh_scholar/cli_tools/audio_transcribe/audio_transcribe.py tests/cli_tools/test_audio_transcribe.py tests/cli_tools/test_audio_transcribe_pipeline.py`
- `make pr-check`

## Summary by Sourcery

Normalize audio-transcribe CLI output handling to support structured transcript records and prevent crashes when writing results.

Bug Fixes:
- Prevent audio-transcribe from crashing when the transcription pipeline returns dict-shaped transcript entries instead of plain strings.
- Skip failed transcript chunks gracefully while logging warnings instead of breaking CLI output.

Enhancements:
- Normalize transcription pipeline output into plain text chunks at the CLI boundary so both file writes and stdout rendering share a robust text-only interface.
- Tighten typing for YouTube audio extraction helper to better reflect its usage.

Documentation:
- Document the planned hardening path to make audio-transcribe safe for routine real-world use under fault conditions in TODO.md.
- Record the structured transcript output fix and related behavior changes in the changelog.

Tests:
- Add regression tests covering transcript normalization from string and structured entries, logging of failed chunks, and rejection of invalid transcript payloads.