### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-type-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aaronksolomon/tnh-scholar/security/code-scanning/4](https://github.com/aaronksolomon/tnh-scholar/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs (including `lint-and-type-check`) inherit least-privilege token access. For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (checkout and read operations) while removing implicit broader token rights.  
Edit `.github/workflows/ci.yml` by inserting `permissions:` after the trigger block (`on:` section) and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a root-level permissions block to the CI workflow to grant only read access to repository contents for all jobs.