### PR TITLE
[codex] Fix prompt catalog stage 1 tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Prompt Catalog Stage 1 Tooling Fixes** (2026-04-26)
+  - Fixed filesystem prompt-catalog listing for relative `--prompt-dir` usage so `tnh-gen --prompt-dir ./prompts list` no longer double-prefixes prompt paths
+  - Normalized legacy `output_mode: text` prompt metadata without spurious catalog warnings, leaving only real validation issues visible during catalog health checks
+  - Added focused prompt-system regression coverage for relative repository paths and legacy text-mode metadata handling
+  - Files: `src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py`, `src/tnh_scholar/prompt_system/mappers/prompt_mapper.py`, `tests/prompt_system/test_catalog_adapters.py`, `tests/prompt_system/test_mapper.py`
+
 - **CI Workflow Cleanup and Docs Validation Split** (2026-04-26)
   - Replaced the old overloaded CI workflow with separate PR validation, `main` validation/test, and scheduled weekly full-test workflows
   - Split docs CI into read-only PR validation and a separate `main` publish path, removing docs generation from PR verification

--- a/TODO.md
+++ b/TODO.md
@@ -629,6 +629,9 @@ docs/architecture/jvb-viewer/adr/
 - **Tasks**:
   - [x] Aggregate catalog parse/validation issues into typed health reports
   - [x] Surface catalog health through `tnh-gen list` and `tnh-gen config show --catalog-health`
+  - [x] Fix relative `--prompt-dir` prompt catalog path resolution and remove bogus legacy `output_mode: text` warnings
+  - [ ] Normalize legacy prompt frontmatter to PT05 baseline (`role`, `inputs`, explicit `output_contract`)
+  - [ ] Add `schema_ref` coverage for maintained JSON prompts
   - [ ] Add manifest validation
   - [ ] Better error messages (unknown prompt, hash mismatch)
   - [ ] Front-matter/schema validation guidance

--- a/TODO.md
+++ b/TODO.md
@@ -634,7 +634,7 @@ docs/architecture/jvb-viewer/adr/
   - [ ] Add `schema_ref` coverage for maintained JSON prompts
   - [ ] Add manifest validation
   - [ ] Better error messages (unknown prompt, hash mismatch)
-  - [ ] Front-matter/schema validation guidance
+  - [ ] Frontmatter/schema validation guidance
   - [ ] Document prompt schema
 
 #### 🚧 Knowledge Base Implementation

--- a/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
+++ b/src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py
@@ -65,7 +65,7 @@ class FilesystemPromptCatalog(PromptCatalogPort):
         for path in files:
             key = self._mapper.to_key_from_path(path, self._config.repository_path)
             request = PromptFileRequest(
-                path=self._mapper.to_file_request(key, self._config.repository_path),
+                path=path,
                 commit_sha=None,
             )
             file_resp = self._transport.read_file(request)

--- a/src/tnh_scholar/prompt_system/mappers/prompt_mapper.py
+++ b/src/tnh_scholar/prompt_system/mappers/prompt_mapper.py
@@ -30,6 +30,10 @@ class PromptMapper:
                 relative = path
         else:
             relative = path
+            try:
+                relative = relative.relative_to(base_path)
+            except ValueError:
+                pass
         relative = relative.with_suffix("")
         return relative.as_posix()
 
@@ -168,6 +172,8 @@ class PromptMapper:
             return {"mode": "json"}
         if legacy_mode == "artifacts":
             return {"mode": "artifacts", "artifacts": []}
+        if legacy_mode == "text":
+            return {"mode": "text"}
         if legacy_mode is not None:
             warnings.append(
                 f"Frontmatter field 'output_mode' invalid; got '{legacy_mode}'. Defaulting to 'text'."

--- a/src/tnh_scholar/prompt_system/mappers/prompt_mapper.py
+++ b/src/tnh_scholar/prompt_system/mappers/prompt_mapper.py
@@ -22,7 +22,13 @@ class PromptMapper:
         return base_path / f"{canonical_key}.md"
 
     def to_key_from_path(self, path: Path, base_path: Path) -> str:
-        """Map a prompt file path to canonical key."""
+        """Map a prompt file path to canonical key.
+
+        Absolute paths are relativized only when they live under ``base_path``.
+        Relative paths also strip a matching relative ``base_path`` prefix, which
+        keeps ``prompts/foo.md`` and ``foo.md`` equivalent for callers such as
+        ``--prompt-dir ./prompts``. Paths outside the base are preserved.
+        """
         if path.is_absolute():
             try:
                 relative = path.relative_to(base_path)

--- a/tests/prompt_system/test_catalog_adapters.py
+++ b/tests/prompt_system/test_catalog_adapters.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from tnh_scholar.prompt_system.adapters.filesystem_catalog_adapter import (
     FilesystemPromptCatalog,
 )
@@ -84,20 +86,25 @@ def test_filesystem_catalog_list_returns_namespaced_keys(tmp_path: Path):
     assert keys == ["agent-orch/planner/evaluate", "core/task/summarize"]
 
 
-def test_filesystem_catalog_list_supports_relative_repository_path(tmp_path: Path, monkeypatch):
+@pytest.mark.parametrize(
+    "repository_path",
+    [Path("prompts"), Path("./prompts")],
+)
+def test_filesystem_catalog_list_supports_relative_repository_path(
+    tmp_path: Path,
+    monkeypatch,
+    repository_path: Path,
+):
     relative_repo = tmp_path / "prompts"
     write_prompt(relative_repo, "agent-orch/planner/evaluate")
-    original_cwd = Path.cwd()
     monkeypatch.chdir(tmp_path)
-    try:
-        config = PromptCatalogConfig(repository_path=Path("prompts"))
-        mapper = PromptMapper()
-        loader = PromptLoader(PromptValidator(ValidationPolicy()))
-        catalog = FilesystemPromptCatalog(config, mapper=mapper, loader=loader)
 
-        keys = [metadata.canonical_key() for metadata in catalog.list()]
-    finally:
-        monkeypatch.chdir(original_cwd)
+    config = PromptCatalogConfig(repository_path=repository_path)
+    mapper = PromptMapper()
+    loader = PromptLoader(PromptValidator(ValidationPolicy()))
+    catalog = FilesystemPromptCatalog(config, mapper=mapper, loader=loader)
+
+    keys = [metadata.canonical_key() for metadata in catalog.list()]
 
     assert keys == ["agent-orch/planner/evaluate"]
 

--- a/tests/prompt_system/test_catalog_adapters.py
+++ b/tests/prompt_system/test_catalog_adapters.py
@@ -84,6 +84,24 @@ def test_filesystem_catalog_list_returns_namespaced_keys(tmp_path: Path):
     assert keys == ["agent-orch/planner/evaluate", "core/task/summarize"]
 
 
+def test_filesystem_catalog_list_supports_relative_repository_path(tmp_path: Path, monkeypatch):
+    relative_repo = tmp_path / "prompts"
+    write_prompt(relative_repo, "agent-orch/planner/evaluate")
+    original_cwd = Path.cwd()
+    monkeypatch.chdir(tmp_path)
+    try:
+        config = PromptCatalogConfig(repository_path=Path("prompts"))
+        mapper = PromptMapper()
+        loader = PromptLoader(PromptValidator(ValidationPolicy()))
+        catalog = FilesystemPromptCatalog(config, mapper=mapper, loader=loader)
+
+        keys = [metadata.canonical_key() for metadata in catalog.list()]
+    finally:
+        monkeypatch.chdir(original_cwd)
+
+    assert keys == ["agent-orch/planner/evaluate"]
+
+
 def test_filesystem_catalog_get_accepts_immutable_reference(tmp_path: Path):
     write_prompt(tmp_path, "agent-orch/planner/evaluate", "Hi {{who}}")
     config = PromptCatalogConfig(repository_path=tmp_path)

--- a/tests/prompt_system/test_mapper.py
+++ b/tests/prompt_system/test_mapper.py
@@ -25,6 +25,14 @@ def test_to_key_from_path_supports_absolute_and_relative_paths(tmp_path: Path):
     assert mapper.to_key_from_path(relative, base_path) == "agent-orch/planner/evaluate"
 
 
+def test_to_key_from_path_strips_relative_base_prefix():
+    mapper = PromptMapper()
+    base_path = Path("prompts")
+    relative = Path("prompts/agent-orch/planner/evaluate.md")
+
+    assert mapper.to_key_from_path(relative, base_path) == "agent-orch/planner/evaluate"
+
+
 def test_to_key_from_path_keeps_absolute_path_when_not_under_base(tmp_path: Path):
     mapper = PromptMapper()
     base_path = tmp_path / "prompts"
@@ -108,6 +116,27 @@ Evaluate planner output.
     assert names_to_specs["harness_report"].strictness.value == "strict"
     assert not names_to_specs["context_notes"].required
     assert names_to_specs["context_notes"].strictness.value == "loose"
+
+
+def test_to_domain_prompt_accepts_legacy_text_output_mode_without_warning():
+    mapper = PromptMapper()
+    content = """---
+key: agent-orch/planner/evaluate
+name: Planner Evaluate
+version: 1
+description: Evaluate planner output.
+role: planner
+required_variables: []
+output_mode: text
+---
+Evaluate planner output.
+"""
+
+    prompt = mapper.to_domain_prompt(content)
+
+    assert prompt.metadata.output_contract is not None
+    assert prompt.metadata.output_contract.mode.value == "text"
+    assert prompt.metadata.warnings == []
 
 
 def test_to_domain_prompt_normalizes_artifact_output_entries():


### PR DESCRIPTION
## What changed
- fixed filesystem prompt-catalog listing for relative `--prompt-dir` usage so `tnh-gen --prompt-dir ./prompts list` no longer double-prefixes prompt paths
- normalized legacy `output_mode: text` metadata without spurious catalog warnings
- added focused regression coverage for relative repository paths and legacy text-mode prompt metadata
- updated `CHANGELOG.md` and the existing `Prompt Catalog Safety` TODO bucket to record stage 1 completion and the remaining normalization work

## Why
Stage 1 of the prompt modernization sequence was to fix the catalog/tooling defects first, so later prompt metadata cleanup can be validated through the maintained `tnh-gen` path without false warning noise or broken relative prompt-dir resolution.

## Impact
- `tnh-gen --prompt-dir ./prompts --api --format json list` now works correctly from the repo root
- catalog health output now surfaces the real remaining issues, especially missing JSON `schema_ref` metadata, instead of warning on valid text-mode legacy prompts
- the remaining prompt modernization work is now easier to sequence in follow-up PRs

## Validation
- `make pr-check`
- `poetry run ruff check src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py src/tnh_scholar/prompt_system/mappers/prompt_mapper.py tests/prompt_system/test_catalog_adapters.py tests/prompt_system/test_mapper.py`
- `poetry run mypy src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py src/tnh_scholar/prompt_system/mappers/prompt_mapper.py tests/prompt_system/test_catalog_adapters.py tests/prompt_system/test_mapper.py`
- `poetry run sourcery review src/tnh_scholar/prompt_system/adapters/filesystem_catalog_adapter.py src/tnh_scholar/prompt_system/mappers/prompt_mapper.py tests/prompt_system/test_catalog_adapters.py tests/prompt_system/test_mapper.py 2>&1`
- `make ci-check`

## Summary by Sourcery

Fix prompt catalog tooling to correctly handle relative repository paths and legacy text-mode prompt metadata while documenting the changes and updating validation coverage.

Bug Fixes:
- Resolve incorrect prompt key generation when listing prompts from a relative repository path, preventing double-prefixing of prompt paths.
- Treat legacy `output_mode: text` values as valid text-mode output contracts instead of emitting spurious catalog warnings.

Enhancements:
- Adjust filesystem catalog listing to read files directly from discovered paths rather than re-derived request paths for more robust resolution.

Documentation:
- Document prompt catalog tooling fixes and stage 1 completion in the changelog and update the prompt catalog safety TODOs to reflect remaining normalization work.

Tests:
- Add regression tests for relative repository path handling in the filesystem prompt catalog and for accepting legacy text output mode metadata without warnings.