### PR TITLE
Document prompt catalog stage 2 normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Prompt Catalog Stage 2 Metadata Normalization** (2026-04-26)
+  - Normalized the maintained `prompts/` catalog to the PT05 metadata baseline by adding explicit `role`, `inputs`, and `output_contract` fields across the legacy prompt set
+  - Added concrete `schema_ref` coverage for the maintained JSON prompts so prompt catalog health now loads cleanly through `tnh-gen`
+  - Removed obsolete `review_count` variables and instructions from legacy prompts because they are not part of the modern-model operating contract
+  - Files: `prompts/`, `TODO.md`
+
 - **Prompt Catalog Stage 1 Tooling Fixes** (2026-04-26)
   - Fixed filesystem prompt-catalog listing for relative `--prompt-dir` usage so `tnh-gen --prompt-dir ./prompts list` no longer double-prefixes prompt paths
   - Normalized legacy `output_mode: text` prompt metadata without spurious catalog warnings, leaving only real validation issues visible during catalog health checks

--- a/TODO.md
+++ b/TODO.md
@@ -630,8 +630,9 @@ docs/architecture/jvb-viewer/adr/
   - [x] Aggregate catalog parse/validation issues into typed health reports
   - [x] Surface catalog health through `tnh-gen list` and `tnh-gen config show --catalog-health`
   - [x] Fix relative `--prompt-dir` prompt catalog path resolution and remove bogus legacy `output_mode: text` warnings
-  - [ ] Normalize legacy prompt frontmatter to PT05 baseline (`role`, `inputs`, explicit `output_contract`)
-  - [ ] Add `schema_ref` coverage for maintained JSON prompts
+  - [x] Normalize legacy prompt frontmatter to PT05 baseline (`role`, `inputs`, explicit `output_contract`)
+  - [x] Add `schema_ref` coverage for maintained JSON prompts
+  - [ ] Simplify overlapping legacy prompt bodies and retire redundant variants
   - [ ] Add manifest validation
   - [ ] Better error messages (unknown prompt, hash mismatch)
   - [ ] Frontmatter/schema validation guidance


### PR DESCRIPTION
## Summary
- document the completed stage-2 prompt catalog normalization work
- mark PT05 frontmatter normalization and JSON `schema_ref` coverage complete in `TODO.md`
- record the stage-2 prompt catalog modernization entry in `CHANGELOG.md`

## Validation
- `poetry run tnh-gen --prompt-dir ./prompts --api --format json list`
- `poetry run pytest tests/prompt_system/test_mapper.py tests/prompt_system/test_catalog_adapters.py tests/cli_tools/test_tnh_gen.py -q`
- `make pr-check`
- `poetry run sourcery review TODO.md CHANGELOG.md 2>&1`
- `make ci-check`

## Summary by Sourcery

Document completion of stage-2 prompt catalog metadata normalization and update project tracking files.

Documentation:
- Add changelog entry describing stage-2 prompt catalog metadata normalization, including PT05 baseline alignment and JSON schema coverage.

Chores:
- Update TODO checklist to mark PT05 frontmatter normalization and JSON schema_ref coverage as complete and add a follow-up task to simplify legacy prompt variants.