### PR TITLE
[codex] Fix tnh-gen vars file reuse workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tnh-gen --vars` Generated-Artifact Compatibility** (2026-04-28)
+  - Taught `tnh-gen run --vars` to accept JSON objects wrapped in YAML frontmatter so staged `tnh-gen` workflows can feed generated JSON artifacts into later prompt runs without manual stripping
+  - Preserved the existing failure contract for non-object payloads and frontmatter-wrapped bodies that are still not valid JSON
+  - Added focused CLI and loader regression coverage for frontmatter-wrapped vars files
+  - Files: `src/tnh_scholar/cli_tools/tnh_gen/commands/run.py`, `tests/cli_tools/test_tnh_gen.py`, `tests/cli_tools/test_tnh_gen_coverage.py`
+
 - **Prompt Catalog Stage 2 Metadata Normalization** (2026-04-26)
   - Normalized the maintained `prompts/` catalog to the PT05 metadata baseline by adding explicit `role`, `inputs`, and `output_contract` fields across the legacy prompt set
   - Added concrete `schema_ref` coverage for the maintained JSON prompts so prompt catalog health now loads cleanly through `tnh-gen`

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
@@ -125,12 +125,21 @@ def _load_vars_file(path: Path | None) -> VariableMap:
     """
     if path is None:
         return {}
+    raw_text = path.read_text(encoding="utf-8")
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(raw_text)
     except json.JSONDecodeError as exc:
-        raise json.JSONDecodeError(
-            f"Invalid JSON in vars file {path}", exc.doc, exc.pos
-        ) from exc
+        _, body = Frontmatter.extract(raw_text)
+        if body == raw_text:
+            raise json.JSONDecodeError(
+                f"Invalid JSON in vars file {path}", exc.doc, exc.pos
+            ) from exc
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as body_exc:
+            raise json.JSONDecodeError(
+                f"Invalid JSON in vars file {path}", body_exc.doc, body_exc.pos
+            ) from body_exc
     if not isinstance(payload, dict):
         raise ValueError("--vars file must contain a JSON object")
     return {str(k): v for k, v in payload.items()}

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -1291,6 +1291,117 @@ def test_run_reports_non_object_vars_file(tmp_path, monkeypatch):
     assert "--vars file must contain a JSON object" in payload["error"]
 
 
+def test_run_accepts_frontmatter_wrapped_json_vars_file(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    vars_file = tmp_path / "vars.json"
+    vars_file.write_text(
+        (
+            "---\n"
+            "tnh_scholar_generated: true\n"
+            "prompt_key: section_by_break\n"
+            "---\n\n"
+            '{"audience":"from_vars","section_count":4}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _StubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--vars",
+            str(vars_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "succeeded"
+    assert stub_service.last_request.variables["audience"] == "from_vars"
+    assert stub_service.last_request.variables["section_count"] == 4
+
+
+def test_run_reports_frontmatter_wrapped_non_json_vars_body(tmp_path, monkeypatch):
+    prompt_dir = _write_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    vars_file = tmp_path / "vars.json"
+    vars_file.write_text(
+        (
+            "---\n"
+            "tnh_scholar_generated: true\n"
+            "---\n\n"
+            "sections:\n"
+            "  - start_line: 1\n"
+        ),
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="daily",
+        name="Daily Guidance",
+        version="1.0.0",
+        description="Daily guidance prompt for testing.",
+        task_type="study-plan",
+        required_variables=["audience"],
+        optional_variables=[],
+        default_variables={},
+        tags=["guidance"],
+    )
+    stub_service = _StubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "daily",
+            "--input-file",
+            str(input_file),
+            "--vars",
+            str(vars_file),
+        ],
+    )
+
+    assert result.exit_code == 4
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert "Invalid JSON" in payload["error"]
+
+
 def test_cli_loads_dotenv_for_settings(tmp_path, monkeypatch):
     dotenv_path = tmp_path / ".env"
     dotenv_path.write_text("OPENAI_API_KEY=from_dotenv\n", encoding="utf-8")

--- a/tests/cli_tools/test_tnh_gen_coverage.py
+++ b/tests/cli_tools/test_tnh_gen_coverage.py
@@ -519,6 +519,24 @@ def test_provenance_write_without_header(tmp_path):
     assert output_file.read_text(encoding="utf-8") == "plain text"
 
 
+def test_load_vars_file_accepts_frontmatter_wrapped_json(tmp_path):
+    vars_file = tmp_path / "vars.json"
+    vars_file.write_text(
+        (
+            "---\n"
+            "tnh_scholar_generated: true\n"
+            "prompt_key: daily\n"
+            "---\n\n"
+            '{"audience":"students","count":2}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    payload = run_module._load_vars_file(vars_file)
+
+    assert payload == {"audience": "students", "count": 2}
+
+
 def test_provenance_yaml_roundtrip(tmp_path):
     output_file = tmp_path / "output.txt"
     envelope = _envelope_with_warnings()


### PR DESCRIPTION
## Summary
Fix `tnh-gen run --vars` so staged `tnh-gen` pipelines can reuse generated JSON artifacts without manually stripping YAML frontmatter.

## Root Cause
`--vars` only accepted raw JSON objects, but `tnh-gen` output files written through the provenance path prepend YAML frontmatter by default. That made a generated `sections.json` artifact unusable as a later `--vars` input even when its body was valid JSON.

## What Changed
- updated the `--vars` loader to first try raw JSON, then fall back to parsing the body after frontmatter when present
- kept the existing failure behavior for non-object payloads
- kept frontmatter-wrapped non-JSON bodies failing clearly as invalid JSON
- added focused regression coverage for frontmatter-wrapped vars files at both loader and CLI levels
- added an unreleased changelog entry

## Validation
- `python -m pytest tests/cli_tools/test_tnh_gen.py tests/cli_tools/test_tnh_gen_coverage.py -q`
- `python -m pytest tests/cli_tools/test_tnh_gen.py -q -k 'frontmatter_wrapped_json_vars_file or frontmatter_wrapped_non_json_vars_body or non_object_vars_file'`
- `python -m pytest tests/cli_tools/test_tnh_gen_coverage.py -q -k 'load_vars_file_accepts_frontmatter_wrapped_json or provenance_write_without_header'`
- `python -m ruff check src/tnh_scholar/cli_tools/tnh_gen/commands/run.py tests/cli_tools/test_tnh_gen.py tests/cli_tools/test_tnh_gen_coverage.py`
- `python -m mypy src/tnh_scholar/cli_tools/tnh_gen/commands/run.py tests/cli_tools/test_tnh_gen.py tests/cli_tools/test_tnh_gen_coverage.py`
- `python scripts/pr_readiness.py --base origin/main --pytest-target tests/cli_tools/test_tnh_gen.py --pytest-target tests/cli_tools/test_tnh_gen_coverage.py`

## Notes
Sourcery review could not be run locally because the installed Sourcery account tier does not include the CLI review feature.

## Summary by Sourcery

Update tnh-gen vars loading to support YAML-frontmatter-wrapped JSON artifacts and document the change.

Bug Fixes:
- Allow tnh-gen run --vars to consume JSON vars files wrapped in YAML frontmatter while preserving clear failures for invalid JSON and non-object payloads.

Documentation:
- Add unreleased changelog entry describing tnh-gen --vars compatibility with generated artifacts.

Tests:
- Add CLI and loader regression tests covering frontmatter-wrapped JSON vars files, non-JSON frontmatter bodies, and provenance behavior.