### PR TITLE
Implement tnh-gen structured JSON contract validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tnh-gen` Structured JSON Contract Runtime Validation** (2026-05-01)
+  - Added prompt-contract schema resolution and validation with workspace, user, and built-in precedence for maintained JSON prompts
+  - Wired `tnh-gen` and `GenAIService` to enforce JSON prompt contracts at both catalog time and post-invocation runtime, including typed `CONTRACT_VALIDATION_FAILED` handling
+  - Updated the OpenAI path to use provider-native `json_schema` structured output requests while retaining local schema validation as the authoritative contract check
+  - Ensured JSON prompt `--output-file` writes remain canonical JSON text without YAML provenance headers, preserving downstream machine-readability
+  - Added focused prompt-system, service, CLI, and provenance regression coverage for structured JSON success, failure, and missing-schema paths
+  - Files: `src/tnh_scholar/prompt_system/service/contract_schema.py`, `src/tnh_scholar/prompt_system/service/validator.py`, `src/tnh_scholar/gen_ai_service/`, `src/tnh_scholar/cli_tools/tnh_gen/`, `src/tnh_scholar/runtime_assets/schemas/`, `tests/prompt_system/`, `tests/gen_ai_service/`, `tests/cli_tools/`
+
 - **`tnh-gen --vars` Generated-Artifact Compatibility** (2026-04-28)
   - Taught `tnh-gen run --vars` to accept JSON objects wrapped in YAML frontmatter so staged `tnh-gen` workflows can feed generated JSON artifacts into later prompt runs without manual stripping
   - Preserved the existing failure contract for non-object payloads and frontmatter-wrapped bodies that are still not valid JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added prompt-contract schema resolution and validation with workspace, user, and built-in precedence for maintained JSON prompts
   - Wired `tnh-gen` and `GenAIService` to enforce JSON prompt contracts at both catalog time and post-invocation runtime, including typed `CONTRACT_VALIDATION_FAILED` handling
   - Updated the OpenAI path to use provider-native `json_schema` structured output requests while retaining local schema validation as the authoritative contract check
-  - Ensured JSON prompt `--output-file` writes remain canonical JSON text without YAML provenance headers, preserving downstream machine-readability
+  - Ensured JSON prompt `--output-file` writes remain canonical JSON text and moved persisted provenance for structured outputs into adjacent `.provenance.yaml` sidecars
   - Added focused prompt-system, service, CLI, and provenance regression coverage for structured JSON success, failure, and missing-schema paths
-  - Files: `src/tnh_scholar/prompt_system/service/contract_schema.py`, `src/tnh_scholar/prompt_system/service/validator.py`, `src/tnh_scholar/gen_ai_service/`, `src/tnh_scholar/cli_tools/tnh_gen/`, `src/tnh_scholar/runtime_assets/schemas/`, `tests/prompt_system/`, `tests/gen_ai_service/`, `tests/cli_tools/`
+  - Files: `src/tnh_scholar/prompt_system/service/contract_schema.py`, `src/tnh_scholar/prompt_system/service/validator.py`, `src/tnh_scholar/gen_ai_service/`, `src/tnh_scholar/cli_tools/tnh_gen/`, `src/tnh_scholar/runtime_assets/schemas/`, `docs/architecture/tnh-gen/adr/adr-tg04.2-structured-json-provenance-sidecars.md`, `tests/prompt_system/`, `tests/gen_ai_service/`, `tests/cli_tools/`
 
 - **`tnh-gen --vars` Generated-Artifact Compatibility** (2026-04-28)
   - Taught `tnh-gen run --vars` to accept JSON objects wrapped in YAML frontmatter so staged `tnh-gen` workflows can feed generated JSON artifacts into later prompt runs without manual stripping

--- a/docs/architecture/tnh-gen/adr/adr-tg04.2-structured-json-provenance-sidecars.md
+++ b/docs/architecture/tnh-gen/adr/adr-tg04.2-structured-json-provenance-sidecars.md
@@ -1,0 +1,101 @@
+---
+title: "ADR-TG04.2: Structured JSON Provenance Sidecars"
+description: "Clarify how tnh-gen preserves first-class provenance for structured JSON outputs without violating JSON artifact purity."
+type: "design-detail"
+owner: "aaronksolomon"
+author: "Aaron Solomon, OpenAI Codex"
+status: accepted
+created: "2026-05-01"
+parent_adr: "adr-tg04-structured-json-contract-and-scope.md"
+related_adrs:
+  - "adr-tg04.1-json-contract-runtime-validation.md"
+  - "adr-tg01.1-human-friendly-defaults.md"
+---
+# ADR-TG04.2: Structured JSON Provenance Sidecars
+
+Clarify where provenance lives for structured JSON output artifacts produced by `tnh-gen`.
+
+- **Filename**: `adr-tg04.2-structured-json-provenance-sidecars.md`
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Authors**: Aaron Solomon, OpenAI Codex
+- **Owner**: aaronksolomon
+- **Parent ADR**: [ADR-TG04: Structured JSON Contract and Scope Boundaries](/architecture/tnh-gen/adr/adr-tg04-structured-json-contract-and-scope.md)
+
+---
+
+## Context
+
+ADR-TG04.1 established two requirements that conflict if provenance remains inline:
+
+- structured JSON `--output-file` artifacts must remain canonical JSON text
+- provenance is a first-class TNH Scholar concern and should remain durable on disk
+
+The older file-writing convention used YAML frontmatter inline with file content.
+That works for text artifacts, but it breaks the ordinary contract of a JSON file.
+A JSON artifact that requires TNH-specific frontmatter stripping is no longer a normal JSON artifact.
+
+We want both:
+
+- standard JSON files that downstream tools can parse directly
+- retained provenance and source metadata for TNH workflows
+
+---
+
+## Decision
+
+### 1. Structured JSON Output Files Remain Pure JSON
+
+When a prompt output contract is `json`, the primary `--output-file` artifact must contain only canonical JSON text.
+
+No YAML frontmatter or other inline metadata may be prefixed to the JSON artifact.
+
+### 2. Provenance Moves to a Sidecar File
+
+When a structured JSON output is written to disk, provenance is written to a deterministic sidecar YAML file alongside the JSON artifact.
+
+Path rule:
+
+- primary artifact: `<output-path>`
+- provenance sidecar: `<output-path>.provenance.yaml`
+
+Examples:
+
+- `sections.json`
+- `sections.json.provenance.yaml`
+
+### 3. Sidecar Content Rules
+
+If provenance is enabled, the sidecar stores the same merged metadata that would otherwise have appeared in inline frontmatter:
+
+- TNH Scholar generated markers
+- prompt key and prompt version
+- model and fingerprint
+- trace id and generation timestamp
+- preserved source metadata when present
+
+If provenance is disabled but source metadata exists, the sidecar stores the preserved source metadata only.
+
+If neither provenance nor source metadata is present, no sidecar file is written.
+
+### 4. Text Outputs Keep Existing Inline Behavior
+
+This addendum applies only to structured JSON output artifacts.
+
+Text outputs continue using the existing inline frontmatter behavior because text artifacts do not carry the same machine-parseability expectation as JSON files.
+
+---
+
+## Consequences
+
+- JSON artifacts remain standard JSON files and can be consumed by ordinary tooling without custom preprocessing.
+- Provenance remains durable and first-class on disk for TNH Scholar workflows.
+- Downstream consumers that want both payload and provenance must read two adjacent artifacts instead of one mixed-format file.
+
+---
+
+## Rejected Alternative
+
+### Inline YAML Frontmatter in `.json` Files
+
+Rejected because it redefines a JSON artifact into a TNH-specific pseudo-format and breaks the ordinary expectations of generic JSON tooling, schema validators, editors, and downstream automation.

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
@@ -355,9 +355,8 @@ def _result_payload_from_envelope(envelope: CompletionEnvelope) -> RunResultPayl
         "usage": usage_payload,
         "finish_reason": result.finish_reason,
     }
-    if result.json_value is not None:
-        payload["json"] = result.json_value
     if result.schema_ref is not None:
+        payload["json"] = result.json_value
         payload["schema_ref"] = result.schema_ref
     return payload
 

--- a/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/commands/run.py
@@ -33,12 +33,13 @@ from tnh_scholar.gen_ai_service.models.domain import (
     CompletionEnvelope,
     CompletionFailure,
     CompletionOutcomeStatus,
+    FailureReason,
     RenderRequest,
 )
 from tnh_scholar.gen_ai_service.models.errors import SafetyBlocked
 from tnh_scholar.gen_ai_service.protocols import GenAIServiceProtocol
 from tnh_scholar.metadata import Frontmatter, Metadata
-from tnh_scholar.prompt_system.domain.models import PromptMetadata
+from tnh_scholar.prompt_system.domain.models import PromptMetadata, PromptOutputMode
 
 logger = logging.getLogger(__name__)
 
@@ -347,13 +348,18 @@ def _result_payload_from_envelope(envelope: CompletionEnvelope) -> RunResultPayl
             "total_tokens": result.usage.total_tokens,
         }
 
-    return {
+    payload: RunResultPayload = {
         "text": result.text,
         "model": result.model,
         "provider": result.provider,
         "usage": usage_payload,
         "finish_reason": result.finish_reason,
     }
+    if result.json_value is not None:
+        payload["json"] = result.json_value
+    if result.schema_ref is not None:
+        payload["schema_ref"] = result.schema_ref
+    return payload
 
 
 def _provenance_payload(
@@ -600,10 +606,14 @@ def _emit_run_output(
             context.output_format,
             api,
         )
-        raise typer.Exit(code=int(ExitCode.PROVIDER_ERROR))
+        raise typer.Exit(code=int(_failed_completion_exit_code(envelope)))
 
     result_text = envelope.result.text if envelope.result else ""
     if context.output_file:
+        is_structured_output = (
+            context.metadata.output_contract is not None
+            and context.metadata.output_contract.mode is PromptOutputMode.json
+        )
         write_output_file(
             context.output_file,
             result_text=result_text,
@@ -612,10 +622,18 @@ def _emit_run_output(
             trace_id=context.trace_id,
             prompt_version=context.metadata.version,
             include_provenance=context.include_provenance,
+            structured_output=is_structured_output,
         )
         if not api:
             typer.echo(f"Wrote output to {context.output_file}", err=True)
     _emit_stdout(payload, result_text, context.output_format, api)
+
+
+def _failed_completion_exit_code(envelope: CompletionEnvelope) -> ExitCode:
+    reason = envelope.failure.reason if envelope.failure is not None else None
+    if reason is FailureReason.CONTRACT_VALIDATION_FAILED:
+        return ExitCode.FORMAT_ERROR
+    return ExitCode.PROVIDER_ERROR
 
 
 def _execute_prompt(context: RunContext) -> tuple[CompletionEnvelope, RunOutcomePayload]:

--- a/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
@@ -56,11 +56,15 @@ def write_output_file(
     trace_id: str,
     prompt_version: str | None,
     include_provenance: bool,
+    structured_output: bool = False,
 ) -> None:
     """Write result text to disk, optionally prefixing provenance metadata."""
     if envelope.outcome is CompletionOutcomeStatus.FAILED:
         raise ValueError("Cannot write output for a failed completion outcome")
     path.parent.mkdir(parents=True, exist_ok=True)
+    if structured_output:
+        path.write_text(result_text, encoding="utf-8")
+        return
     if include_provenance:
         header = provenance_block(
             envelope,

--- a/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/output/provenance.py
@@ -27,9 +27,29 @@ def provenance_block(
     prompt_version: str | None,
 ) -> str:
     """Build a YAML frontmatter block capturing provenance for saved files."""
+    return str(
+        Frontmatter.generate(
+            provenance_metadata(
+                envelope,
+                source_metadata=source_metadata,
+                trace_id=trace_id,
+                prompt_version=prompt_version,
+            )
+        )
+    )
+
+
+def provenance_metadata(
+    envelope: CompletionEnvelope,
+    *,
+    source_metadata: Metadata | None = None,
+    trace_id: str,
+    prompt_version: str | None,
+) -> Metadata:
+    """Build merged provenance metadata for persisted sidecars or headers."""
     fp = envelope.provenance.fingerprint
     version = prompt_version or "unknown"
-    provenance_metadata = Metadata(
+    generated_metadata = Metadata(
         {
             "tnh_scholar_generated": True,
             "prompt_key": fp.prompt_key,
@@ -41,10 +61,14 @@ def provenance_block(
             "schema_version": "1.0",
         }
     )
-    merged_metadata = provenance_metadata
     if source_metadata:
-        merged_metadata = source_metadata | provenance_metadata
-    return str(Frontmatter.generate(merged_metadata))
+        return source_metadata | generated_metadata
+    return generated_metadata
+
+
+def sidecar_path(path: Path) -> Path:
+    """Return the provenance sidecar path for a structured output artifact."""
+    return path.with_name(f"{path.name}.provenance.yaml")
 
 
 def write_output_file(
@@ -64,6 +88,18 @@ def write_output_file(
     path.parent.mkdir(parents=True, exist_ok=True)
     if structured_output:
         path.write_text(result_text, encoding="utf-8")
+        if include_provenance:
+            sidecar = sidecar_path(path)
+            metadata = provenance_metadata(
+                envelope,
+                source_metadata=source_metadata,
+                trace_id=trace_id,
+                prompt_version=prompt_version,
+            )
+            sidecar.write_text(metadata.to_yaml(), encoding="utf-8")
+        elif source_metadata:
+            sidecar = sidecar_path(path)
+            sidecar.write_text(source_metadata.to_yaml(), encoding="utf-8")
         return
     if include_provenance:
         header = provenance_block(

--- a/src/tnh_scholar/cli_tools/tnh_gen/types.py
+++ b/src/tnh_scholar/cli_tools/tnh_gen/types.py
@@ -138,6 +138,8 @@ class RunResultPayload(TypedDict):
     provider: str | None
     usage: RunUsagePayload | None
     finish_reason: str | None
+    json: NotRequired[Any]
+    schema_ref: NotRequired[str]
 
 
 class RunProvenancePayload(TypedDict):

--- a/src/tnh_scholar/gen_ai_service/models/domain.py
+++ b/src/tnh_scholar/gen_ai_service/models/domain.py
@@ -93,6 +93,7 @@ class FailureReason(str, Enum):
     CONTENT_FIELD_MISSING = "content_field_missing"
     UNSUPPORTED_RESPONSE_SHAPE = "unsupported_response_shape"
     CONTENT_EXTRACTION_ERROR = "content_extraction_error"
+    CONTRACT_VALIDATION_FAILED = "contract_validation_failed"
 
 
 class AdapterDiagnostics(BaseModel):
@@ -108,6 +109,8 @@ class CompletionResult(BaseModel):
     model: str
     provider: str
     parsed: BaseModel | None = None
+    json_value: Any = None
+    schema_ref: str | None = None
     finish_reason: str | None = None
 
 

--- a/src/tnh_scholar/gen_ai_service/models/transport.py
+++ b/src/tnh_scholar/gen_ai_service/models/transport.py
@@ -10,7 +10,7 @@ Connected modules:
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Mapping, Optional, Type
 
 from pydantic import BaseModel
 
@@ -30,7 +30,7 @@ class ProviderRequest(BaseModel):
     temperature: float
     max_output_tokens: int
     seed: Optional[int] = None
-    response_format: Optional[Type[BaseModel]] = None
+    response_format: Optional[Type[BaseModel] | Mapping[str, Any]] = None
 
 
 class ProviderStatus(str, Enum):

--- a/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/pattern_catalog/adapters/prompts_adapter.py
@@ -37,6 +37,9 @@ from tnh_scholar.prompt_system.domain.protocols import (
 from tnh_scholar.prompt_system.mappers.prompt_mapper import PromptMapper
 from tnh_scholar.prompt_system.service.loader import PromptLoader
 from tnh_scholar.prompt_system.service.renderer import PromptRenderer
+from tnh_scholar.prompt_system.service.contract_schema import (
+    PromptContractSchemaResolver,
+)
 from tnh_scholar.prompt_system.service.validator import PromptValidator
 from tnh_scholar.prompt_system.transport.cache import InMemoryCacheTransport
 
@@ -61,8 +64,12 @@ class PromptsAdapter:
 
         render_policy = PromptRenderPolicy()
         validation_policy = ValidationPolicy()
+        schema_resolver = PromptContractSchemaResolver.for_prompt_directory(self._base)
 
-        self._validator = validator or PromptValidator(validation_policy)
+        self._validator = validator or PromptValidator(
+            validation_policy,
+            schema_resolver=schema_resolver,
+        )
         self._renderer = renderer or PromptRenderer(
             render_policy, settings_defaults={}
         )

--- a/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
@@ -29,7 +29,7 @@ TODOs for Hardening:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Mapping, Optional, cast
 
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_message_param import (
@@ -61,7 +61,7 @@ class OpenAIChatCompletionRequest(BaseModel):
     max_completion_tokens: int
     seed: Optional[int] = None
     reasoning_effort: str | None = None
-    response_format: Optional[type[BaseModel]] = None
+    response_format: Optional[type[BaseModel] | Mapping[str, Any]] = None
 
 
 @dataclass(frozen=True)

--- a/src/tnh_scholar/gen_ai_service/providers/openai_client.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_client.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
+from pydantic import BaseModel
 from tenacity import (
     Retrying,
     before_sleep_log,
@@ -75,7 +76,10 @@ class OpenAIClient(ProviderClient):
         if openai_request.reasoning_effort is not None:
             request_kwargs["reasoning_effort"] = openai_request.reasoning_effort
 
-        if openai_request.response_format is not None:
+        if isinstance(openai_request.response_format, type) and issubclass(
+            openai_request.response_format,
+            BaseModel,
+        ):
             return cast(
                 ChatCompletion,
                 self._client.beta.chat.completions.parse(
@@ -83,6 +87,8 @@ class OpenAIClient(ProviderClient):
                     **request_kwargs,
                 ),
             )
+        if openai_request.response_format is not None:
+            request_kwargs["response_format"] = openai_request.response_format
 
         return cast(
             ChatCompletion,

--- a/src/tnh_scholar/gen_ai_service/service.py
+++ b/src/tnh_scholar/gen_ai_service/service.py
@@ -12,9 +12,13 @@ Connected modules:
   - infra.issue_handler.IssueHandler (runtime validation & error hints)
 """
 
+import json
 from datetime import datetime
 from pathlib import Path
 
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+
+from tnh_scholar.exceptions import ConfigurationError
 from tnh_scholar.gen_ai_service.config.params_policy import apply_policy
 from tnh_scholar.gen_ai_service.config.settings import GenAISettings
 from tnh_scholar.gen_ai_service.infra.issue_handler import IssueHandler
@@ -24,7 +28,11 @@ from tnh_scholar.gen_ai_service.mappers.completion_mapper import (
     provider_to_completion,
 )
 from tnh_scholar.gen_ai_service.models.domain import (
+    CompletionFailure,
     CompletionEnvelope,
+    CompletionOutcomeStatus,
+    CompletionResult,
+    FailureReason,
     RenderRequest,
 )
 from tnh_scholar.gen_ai_service.models.transport import ProviderRequest, ProviderResponse
@@ -34,6 +42,12 @@ from tnh_scholar.gen_ai_service.providers.openai_adapter import OpenAIAdapter
 from tnh_scholar.gen_ai_service.providers.openai_client import OpenAIClient
 from tnh_scholar.gen_ai_service.routing.model_router import select_provider_and_model
 from tnh_scholar.gen_ai_service.safety import safety_gate
+from tnh_scholar.prompt_system.domain.models import PromptMetadata, PromptOutputMode
+from tnh_scholar.prompt_system.service.contract_schema import (
+    PromptContractSchemaResolver,
+    ResolvedPromptContractSchema,
+    format_contract_validation_error,
+)
 
 
 class GenAIService:
@@ -53,9 +67,11 @@ class GenAIService:
             raise RuntimeError("GenAIService could not determine a prompt catalog directory")
         self.catalog: PromptCatalogProtocol = PromptsAdapter(prompts_base=prompts_base)
         self.openai_adapter = OpenAIAdapter()
+        self._schema_resolver = PromptContractSchemaResolver.for_prompt_directory(prompts_base)
 
     def generate(self, request: RenderRequest) -> CompletionEnvelope:
         prompt_metadata = self.catalog.introspect(request.instruction_key)
+        resolved_schema = self._resolve_json_schema(prompt_metadata)
         # Adapter / catalog returns a RenderedPrompt and a Fingerprint (per ADR-A12)
         rendered, fingerprint = self.catalog.render(request)
 
@@ -89,6 +105,10 @@ class GenAIService:
             temperature=selection.temperature,
             max_output_tokens=selection.max_output_tokens,
             seed=selection.seed,
+            response_format=_response_format_for_schema(
+                resolved_schema=resolved_schema,
+                provider=selection.provider,
+            ),
         )
 
         started = datetime.now()
@@ -109,12 +129,40 @@ class GenAIService:
             attempt_count=response.attempts,
         )
 
-        return provider_to_completion(
+        envelope = provider_to_completion(
             response,
             provenance=provenance,
             policy_applied=_build_policy_applied(selection.routing_reason, safety_report),
             warnings=list(safety_report.warnings),
         )
+        return self._apply_json_contract(envelope, resolved_schema)
+
+    def _resolve_json_schema(
+        self,
+        prompt_metadata: PromptMetadata,
+    ) -> ResolvedPromptContractSchema | None:
+        contract = prompt_metadata.output_contract
+        if contract is None or contract.mode != PromptOutputMode.json:
+            return None
+        if not contract.schema_ref:
+            raise ConfigurationError("JSON prompt output_contract.schema_ref is required.")
+        return self._schema_resolver.resolve_validated(contract.schema_ref)
+
+    def _apply_json_contract(
+        self,
+        envelope: CompletionEnvelope,
+        resolved_schema: ResolvedPromptContractSchema | None,
+    ) -> CompletionEnvelope:
+        if resolved_schema is None or envelope.result is None:
+            return envelope
+        if envelope.outcome is CompletionOutcomeStatus.FAILED:
+            return envelope
+        try:
+            json_value = json.loads(envelope.result.text)
+            self._schema_resolver.validate_instance(resolved_schema, json_value)
+        except (json.JSONDecodeError, JsonSchemaValidationError) as exc:
+            return _contract_validation_failure(envelope, resolved_schema.schema_ref, exc)
+        return _with_validated_json(envelope, resolved_schema.schema_ref, json_value)
 
 
 def _build_policy_applied(
@@ -130,3 +178,70 @@ def _build_policy_applied(
     if routing_reason is not None:
         policy["routing_reason"] = routing_reason
     return policy
+
+
+def _response_format_for_schema(
+    *,
+    resolved_schema: ResolvedPromptContractSchema | None,
+    provider: str,
+) -> dict[str, object] | None:
+    if resolved_schema is None:
+        return None
+    if provider != "openai":
+        return None
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": _response_format_name(resolved_schema.schema_ref),
+            "strict": True,
+            "schema": resolved_schema.document,
+        },
+    }
+
+
+def _response_format_name(schema_ref: str) -> str:
+    normalized = "".join(
+        char if char.isalnum() or char in {"_", "-"} else "_"
+        for char in schema_ref
+    )
+    return normalized[:64] or "structured_output"
+
+
+def _contract_validation_failure(
+    envelope: CompletionEnvelope,
+    schema_ref: str,
+    error: json.JSONDecodeError | JsonSchemaValidationError,
+) -> CompletionEnvelope:
+    return CompletionEnvelope(
+        outcome=CompletionOutcomeStatus.FAILED,
+        failure=CompletionFailure(
+            reason=FailureReason.CONTRACT_VALIDATION_FAILED,
+            message=format_contract_validation_error(schema_ref=schema_ref, error=error),
+            retryable=False,
+        ),
+        provenance=envelope.provenance,
+        policy_applied=dict(envelope.policy_applied),
+        warnings=list(envelope.warnings),
+    )
+
+
+def _with_validated_json(
+    envelope: CompletionEnvelope,
+    schema_ref: str,
+    json_value: object,
+) -> CompletionEnvelope:
+    result = envelope.result
+    if result is None:
+        return envelope
+    canonical_text = json.dumps(json_value, ensure_ascii=False, separators=(",", ":"))
+    updated_result = CompletionResult(
+        text=canonical_text,
+        usage=result.usage,
+        model=result.model,
+        provider=result.provider,
+        parsed=result.parsed,
+        json_value=json_value,
+        schema_ref=schema_ref,
+        finish_reason=result.finish_reason,
+    )
+    return envelope.model_copy(update={"result": updated_result})

--- a/src/tnh_scholar/gen_ai_service/service.py
+++ b/src/tnh_scholar/gen_ai_service/service.py
@@ -193,7 +193,9 @@ def _response_format_for_schema(
         "type": "json_schema",
         "json_schema": {
             "name": _response_format_name(resolved_schema.schema_ref),
-            "strict": True,
+            # Use schema-guided output without forcing OpenAI's strict subset gate.
+            # Local JSON Schema validation remains the authoritative contract check.
+            "strict": False,
             "schema": resolved_schema.document,
         },
     }

--- a/src/tnh_scholar/prompt_system/service/contract_schema.py
+++ b/src/tnh_scholar/prompt_system/service/contract_schema.py
@@ -1,0 +1,158 @@
+"""Prompt contract schema resolution and validation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError as JsonSchemaValidationError
+from pydantic import BaseModel
+
+from tnh_scholar.configuration.context import TNHContext
+from tnh_scholar.exceptions import ConfigurationError
+
+
+@dataclass(frozen=True)
+class PromptContractSchemaPathPolicy:
+    """Path policy for prompt contract schemas."""
+
+    directory_parts: tuple[str, ...]
+    suffix: str
+
+    @classmethod
+    def default(cls) -> "PromptContractSchemaPathPolicy":
+        """Return the default prompt-contract path policy."""
+        return cls(
+            directory_parts=("schemas", "prompt-contracts"),
+            suffix=".schema.json",
+        )
+
+
+class ResolvedPromptContractSchema(BaseModel):
+    """Resolved prompt-contract schema artifact."""
+
+    schema_ref: str
+    path: Path
+    document: dict[str, Any]
+
+
+class PromptContractSchemaResolver:
+    """Resolve and validate prompt-contract JSON Schema artifacts."""
+
+    def __init__(
+        self,
+        context: TNHContext,
+        policy: PromptContractSchemaPathPolicy | None = None,
+    ) -> None:
+        self._context = context
+        self._policy = policy or PromptContractSchemaPathPolicy.default()
+
+    @classmethod
+    def for_prompt_directory(cls, prompts_base: Path) -> "PromptContractSchemaResolver":
+        """Build a resolver using runtime-context discovery for a prompt directory."""
+        return cls(_context_for_prompt_directory(prompts_base))
+
+    def resolve_validated(self, schema_ref: str) -> ResolvedPromptContractSchema:
+        """Resolve a schema_ref and confirm the artifact is valid JSON Schema."""
+        resolved = self.resolve(schema_ref)
+        self._check_schema_document(resolved)
+        return resolved
+
+    def resolve(self, schema_ref: str) -> ResolvedPromptContractSchema:
+        """Resolve a schema_ref to the highest-precedence schema file."""
+        relative_path = _relative_schema_path(schema_ref, self._policy)
+        roots = self.search_roots()
+        for root in roots:
+            candidate = root / relative_path
+            if candidate.is_file():
+                return ResolvedPromptContractSchema(
+                    schema_ref=schema_ref,
+                    path=candidate,
+                    document=_load_schema_document(candidate),
+                )
+        searched = ", ".join(str(root / relative_path) for root in roots)
+        raise ConfigurationError(
+            f"Prompt contract schema '{schema_ref}' was not found. Searched: {searched}"
+        )
+
+    def validate_instance(
+        self,
+        resolved: ResolvedPromptContractSchema,
+        payload: Any,
+    ) -> None:
+        """Validate a JSON payload against a resolved schema."""
+        Draft202012Validator(resolved.document).validate(payload)
+
+    def search_roots(self) -> list[Path]:
+        """Return schema search roots in workspace/user/built-in precedence."""
+        paths: list[Path] = []
+        if self._context.workspace_root is not None:
+            paths.append(self._root_for(self._context.workspace_root))
+        paths.append(self._root_for(self._context.user_root))
+        paths.append(self._root_for(self._context.builtin_root))
+        return paths
+
+    def _check_schema_document(self, resolved: ResolvedPromptContractSchema) -> None:
+        try:
+            Draft202012Validator.check_schema(resolved.document)
+        except SchemaError as exc:
+            raise ConfigurationError(
+                f"Prompt contract schema '{resolved.schema_ref}' is invalid: {exc.message}"
+            ) from exc
+
+    def _root_for(self, root: Path) -> Path:
+        return root.joinpath(*self._policy.directory_parts)
+
+
+def _context_for_prompt_directory(prompts_base: Path) -> TNHContext:
+    prompts_path = prompts_base.resolve()
+    discovered = TNHContext.discover(start_path=prompts_path)
+    if discovered.workspace_root is not None:
+        return discovered
+    if prompts_path.name != "prompts":
+        return discovered
+    if prompts_path.parent in {discovered.user_root, discovered.builtin_root}:
+        return discovered
+    return TNHContext.discover(
+        workspace_root=prompts_path.parent,
+        user_root=discovered.user_root,
+        start_path=prompts_path,
+    )
+
+
+def _relative_schema_path(
+    schema_ref: str,
+    policy: PromptContractSchemaPathPolicy,
+) -> Path:
+    parts = schema_ref.split(".")
+    if not parts or any(not part.strip() or "/" in part or "\\" in part for part in parts):
+        raise ConfigurationError(f"Invalid prompt contract schema_ref: '{schema_ref}'")
+    return Path(*parts[:-1], f"{parts[-1]}{policy.suffix}")
+
+
+def _load_schema_document(path: Path) -> dict[str, Any]:
+    try:
+        raw_value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ConfigurationError(f"Prompt contract schema file is not valid JSON: {path}") from exc
+    if not isinstance(raw_value, dict):
+        raise ConfigurationError(f"Prompt contract schema must be a JSON object: {path}")
+    return raw_value
+
+
+def format_contract_validation_error(
+    *,
+    schema_ref: str,
+    error: json.JSONDecodeError | JsonSchemaValidationError,
+) -> str:
+    """Build a user-facing contract validation failure message."""
+    if isinstance(error, json.JSONDecodeError):
+        return (
+            f"Generated output for schema '{schema_ref}' was not valid JSON: "
+            f"{error.msg} at line {error.lineno} column {error.colno}."
+        )
+    path = error.json_path
+    return f"Generated JSON did not satisfy schema '{schema_ref}' at {path}: {error.message}"

--- a/src/tnh_scholar/prompt_system/service/contract_schema.py
+++ b/src/tnh_scholar/prompt_system/service/contract_schema.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -14,21 +13,8 @@ from pydantic import BaseModel
 from tnh_scholar.configuration.context import TNHContext
 from tnh_scholar.exceptions import ConfigurationError
 
-
-@dataclass(frozen=True)
-class PromptContractSchemaPathPolicy:
-    """Path policy for prompt contract schemas."""
-
-    directory_parts: tuple[str, ...]
-    suffix: str
-
-    @classmethod
-    def default(cls) -> "PromptContractSchemaPathPolicy":
-        """Return the default prompt-contract path policy."""
-        return cls(
-            directory_parts=("schemas", "prompt-contracts"),
-            suffix=".schema.json",
-        )
+SCHEMA_DIRECTORY_PARTS = ("schemas", "prompt-contracts")
+SCHEMA_SUFFIX = ".schema.json"
 
 
 class ResolvedPromptContractSchema(BaseModel):
@@ -42,13 +28,8 @@ class ResolvedPromptContractSchema(BaseModel):
 class PromptContractSchemaResolver:
     """Resolve and validate prompt-contract JSON Schema artifacts."""
 
-    def __init__(
-        self,
-        context: TNHContext,
-        policy: PromptContractSchemaPathPolicy | None = None,
-    ) -> None:
+    def __init__(self, context: TNHContext) -> None:
         self._context = context
-        self._policy = policy or PromptContractSchemaPathPolicy.default()
 
     @classmethod
     def for_prompt_directory(cls, prompts_base: Path) -> "PromptContractSchemaResolver":
@@ -58,12 +39,17 @@ class PromptContractSchemaResolver:
     def resolve_validated(self, schema_ref: str) -> ResolvedPromptContractSchema:
         """Resolve a schema_ref and confirm the artifact is valid JSON Schema."""
         resolved = self.resolve(schema_ref)
-        self._check_schema_document(resolved)
+        try:
+            Draft202012Validator.check_schema(resolved.document)
+        except SchemaError as exc:
+            raise ConfigurationError(
+                f"Prompt contract schema '{resolved.schema_ref}' is invalid: {exc.message}"
+            ) from exc
         return resolved
 
     def resolve(self, schema_ref: str) -> ResolvedPromptContractSchema:
         """Resolve a schema_ref to the highest-precedence schema file."""
-        relative_path = _relative_schema_path(schema_ref, self._policy)
+        relative_path = _relative_schema_path(schema_ref)
         roots = self.search_roots()
         for root in roots:
             candidate = root / relative_path
@@ -88,34 +74,35 @@ class PromptContractSchemaResolver:
 
     def search_roots(self) -> list[Path]:
         """Return schema search roots in workspace/user/built-in precedence."""
-        paths: list[Path] = []
-        if self._context.workspace_root is not None:
-            paths.append(self._root_for(self._context.workspace_root))
-        paths.append(self._root_for(self._context.user_root))
-        paths.append(self._root_for(self._context.builtin_root))
-        return paths
-
-    def _check_schema_document(self, resolved: ResolvedPromptContractSchema) -> None:
-        try:
-            Draft202012Validator.check_schema(resolved.document)
-        except SchemaError as exc:
-            raise ConfigurationError(
-                f"Prompt contract schema '{resolved.schema_ref}' is invalid: {exc.message}"
-            ) from exc
-
-    def _root_for(self, root: Path) -> Path:
-        return root.joinpath(*self._policy.directory_parts)
+        roots = [
+            root
+            for root in (
+                self._context.workspace_root,
+                self._context.user_root,
+                self._context.builtin_root,
+            )
+            if root is not None
+        ]
+        return [root.joinpath(*SCHEMA_DIRECTORY_PARTS) for root in roots]
 
 
 def _context_for_prompt_directory(prompts_base: Path) -> TNHContext:
     prompts_path = prompts_base.resolve()
     discovered = TNHContext.discover(start_path=prompts_path)
+
+    # Case 1: workspace context is already known.
     if discovered.workspace_root is not None:
         return discovered
+
+    # Case 2: non-standard prompt directory name.
     if prompts_path.name != "prompts":
         return discovered
+
+    # Case 3: user or built-in prompts directory.
     if prompts_path.parent in {discovered.user_root, discovered.builtin_root}:
         return discovered
+
+    # Case 4: repo-local prompts/ folder that should define a workspace root.
     return TNHContext.discover(
         workspace_root=prompts_path.parent,
         user_root=discovered.user_root,
@@ -123,14 +110,11 @@ def _context_for_prompt_directory(prompts_base: Path) -> TNHContext:
     )
 
 
-def _relative_schema_path(
-    schema_ref: str,
-    policy: PromptContractSchemaPathPolicy,
-) -> Path:
+def _relative_schema_path(schema_ref: str) -> Path:
     parts = schema_ref.split(".")
     if not parts or any(not part.strip() or "/" in part or "\\" in part for part in parts):
         raise ConfigurationError(f"Invalid prompt contract schema_ref: '{schema_ref}'")
-    return Path(*parts[:-1], f"{parts[-1]}{policy.suffix}")
+    return Path(*parts[:-1], f"{parts[-1]}{SCHEMA_SUFFIX}")
 
 
 def _load_schema_document(path: Path) -> dict[str, Any]:
@@ -154,5 +138,8 @@ def format_contract_validation_error(
             f"Generated output for schema '{schema_ref}' was not valid JSON: "
             f"{error.msg} at line {error.lineno} column {error.colno}."
         )
-    path = error.json_path
+    path = getattr(error, "json_path", None)
+    if not path:
+        path_segments = [str(segment) for segment in error.path]
+        path = "$" if not path_segments else f"$.{'.'.join(path_segments)}"
     return f"Generated JSON did not satisfy schema '{schema_ref}' at {path}: {error.message}"

--- a/src/tnh_scholar/prompt_system/service/validator.py
+++ b/src/tnh_scholar/prompt_system/service/validator.py
@@ -3,6 +3,7 @@
 import re
 
 from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
+from tnh_scholar.exceptions import ConfigurationError
 
 from ..config.policy import ValidationPolicy
 from ..domain.models import (
@@ -14,6 +15,7 @@ from ..domain.models import (
     ValidationIssue,
 )
 from ..domain.protocols import PromptValidatorPort
+from .contract_schema import PromptContractSchemaResolver
 
 _VERSION_PATTERN = re.compile(r"^\d+(?:\.\d+){0,2}$")
 _ALWAYS_ALLOWED_VARIABLES = {"input_text"}
@@ -22,8 +24,13 @@ _ALWAYS_ALLOWED_VARIABLES = {"input_text"}
 class PromptValidator(PromptValidatorPort):
     """Validates prompt metadata and render parameters."""
 
-    def __init__(self, policy: ValidationPolicy):
+    def __init__(
+        self,
+        policy: ValidationPolicy,
+        schema_resolver: PromptContractSchemaResolver | None = None,
+    ):
         self._policy = policy
+        self._schema_resolver = schema_resolver
 
     def validate(self, prompt: Prompt) -> PromptValidationResult:
         """Validate prompt metadata and template syntax."""
@@ -166,6 +173,12 @@ class PromptValidator(PromptValidatorPort):
                     field="output_contract.schema_ref",
                 )
             )
+        if (
+            contract.mode == PromptOutputMode.json
+            and contract.schema_ref
+            and self._schema_resolver is not None
+        ):
+            self._validate_schema_ref(contract.schema_ref, errors)
         if contract.mode == PromptOutputMode.artifacts and not contract.artifacts:
             errors.append(
                 ValidationIssue(
@@ -173,6 +186,23 @@ class PromptValidator(PromptValidatorPort):
                     code="MISSING_ARTIFACTS",
                     message="Artifacts output mode requires at least one artifact declaration.",
                     field="output_contract.artifacts",
+                )
+            )
+
+    def _validate_schema_ref(
+        self,
+        schema_ref: str,
+        errors: list[ValidationIssue],
+    ) -> None:
+        try:
+            self._schema_resolver.resolve_validated(schema_ref)
+        except ConfigurationError as exc:
+            errors.append(
+                ValidationIssue(
+                    level="error",
+                    code="INVALID_SCHEMA_REF",
+                    message=str(exc),
+                    field="output_contract.schema_ref",
                 )
             )
 

--- a/src/tnh_scholar/runtime_assets/schemas/prompt-contracts/tnh/testing/echo/v1.schema.json
+++ b/src/tnh_scholar/runtime_assets/schemas/prompt-contracts/tnh/testing/echo/v1.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "message"
+  ],
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -602,6 +602,50 @@ class _JsonStubService:
         )
 
 
+class _JsonNullStubService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+
+    def generate(self, request):
+        self.last_request = request
+        started = datetime.now()
+        finished = started + timedelta(seconds=1)
+        return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.SUCCEEDED,
+            result=CompletionResult(
+                text="null",
+                usage=Usage(
+                    prompt_tokens=10,
+                    completion_tokens=20,
+                    total_tokens=30,
+                ),
+                model="gpt-4o",
+                provider="openai",
+                json_value=None,
+                schema_ref="tnh.testing.echo.v1",
+                finish_reason="stop",
+            ),
+            provenance=Provenance(
+                provider="openai",
+                model="gpt-4o",
+                started_at=started,
+                finished_at=finished,
+                attempt_count=1,
+                fingerprint=Fingerprint(
+                    prompt_key="json-echo",
+                    prompt_name="JSON Echo",
+                    prompt_base_path=".",
+                    prompt_content_hash="hash-prompt",
+                    variables_hash="hash-vars",
+                    user_string_hash="hash-input",
+                ),
+            ),
+            policy_applied={"routing_reason": "test"},
+            warnings=[],
+        )
+
+
 class _JsonContractFailedStubService:
     def __init__(self, metadata: PromptMetadata):
         self.last_request: Any = None
@@ -1143,6 +1187,51 @@ def test_run_api_json_prompt_includes_structured_result_and_writes_canonical_jso
     assert sidecar_payload["source"] == "draft"
     assert sidecar_payload["tnh_scholar_generated"] is True
     assert sidecar_payload["prompt_key"] == "json-echo"
+
+
+def test_run_api_json_prompt_preserves_root_null_payload(tmp_path, monkeypatch):
+    prompt_dir = _write_json_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="json-echo",
+        name="JSON Echo",
+        version="1.0.0",
+        description="JSON prompt for testing.",
+        task_type="test",
+        role="task",
+        required_variables=[],
+        optional_variables=[],
+        default_variables={},
+        output_contract={"mode": "json", "schema_ref": "tnh.testing.echo.v1"},
+    )
+    stub_service = _JsonNullStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "json-echo",
+            "--input-file",
+            str(input_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "succeeded"
+    assert "json" in payload["result"]
+    assert payload["result"]["json"] is None
+    assert payload["result"]["schema_ref"] == "tnh.testing.echo.v1"
+    assert payload["result"]["text"] == "null"
 
 
 def test_run_api_contract_validation_failure_uses_format_error_and_skips_output_file(

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -65,6 +65,32 @@ def _write_prompt(tmp_path) -> str:
     return str(prompt_dir)
 
 
+def _write_json_prompt(tmp_path) -> str:
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    prompt_dir.joinpath("json-echo.md").write_text(
+        dedent(
+            """\
+            ---
+            key: json-echo
+            name: JSON Echo
+            version: 1.0.0
+            description: JSON prompt for testing.
+            task_type: test
+            role: task
+            required_variables: []
+            output_contract:
+              mode: json
+              schema_ref: tnh.testing.echo.v1
+            ---
+            Return JSON.
+            """
+        ),
+        encoding="utf-8",
+    )
+    return str(prompt_dir)
+
+
 def _write_legacy_prompt(tmp_path) -> str:
     prompt_dir = tmp_path / "prompts"
     prompt_dir.mkdir()
@@ -532,6 +558,89 @@ class _BudgetBlockedService:
         )
 
 
+class _JsonStubService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+
+    def generate(self, request):
+        self.last_request = request
+        started = datetime.now()
+        finished = started + timedelta(seconds=1)
+        return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.SUCCEEDED,
+            result=CompletionResult(
+                text='{"message":"generated"}',
+                usage=Usage(
+                    prompt_tokens=10,
+                    completion_tokens=20,
+                    total_tokens=30,
+                ),
+                model="gpt-4o",
+                provider="openai",
+                json_value={"message": "generated"},
+                schema_ref="tnh.testing.echo.v1",
+                finish_reason="stop",
+            ),
+            provenance=Provenance(
+                provider="openai",
+                model="gpt-4o",
+                started_at=started,
+                finished_at=finished,
+                attempt_count=1,
+                fingerprint=Fingerprint(
+                    prompt_key="json-echo",
+                    prompt_name="JSON Echo",
+                    prompt_base_path=".",
+                    prompt_content_hash="hash-prompt",
+                    variables_hash="hash-vars",
+                    user_string_hash="hash-input",
+                ),
+            ),
+            policy_applied={"routing_reason": "test"},
+            warnings=[],
+        )
+
+
+class _JsonContractFailedStubService:
+    def __init__(self, metadata: PromptMetadata):
+        self.last_request: Any = None
+        self.catalog = _StubCatalog(metadata)
+
+    def generate(self, request):
+        self.last_request = request
+        started = datetime.now()
+        finished = started + timedelta(seconds=1)
+        return CompletionEnvelope(
+            outcome=CompletionOutcomeStatus.FAILED,
+            failure=CompletionFailure(
+                reason=FailureReason.CONTRACT_VALIDATION_FAILED,
+                message=(
+                    "Generated JSON did not satisfy schema "
+                    "'tnh.testing.echo.v1' at $.message: 1 is not of type 'string'"
+                ),
+                retryable=False,
+            ),
+            provenance=Provenance(
+                provider="openai",
+                model="gpt-4o",
+                started_at=started,
+                finished_at=finished,
+                attempt_count=1,
+                fingerprint=Fingerprint(
+                    prompt_key="json-echo",
+                    prompt_name="JSON Echo",
+                    prompt_base_path=".",
+                    prompt_content_hash="hash-prompt",
+                    variables_hash="hash-vars",
+                    user_string_hash="hash-input",
+                ),
+            ),
+            policy_applied={"routing_reason": "test"},
+            warnings=[],
+        )
+
+
 class _RecordingFactory:
     def __init__(self, service: Any):
         self.service = service
@@ -977,6 +1086,157 @@ def test_run_api_failed_completion_returns_failure_payload_without_file(tmp_path
     assert not output_file.exists()
 
 
+def test_run_api_json_prompt_includes_structured_result_and_writes_canonical_json(
+    tmp_path,
+    monkeypatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    input_file = tmp_path / "input.md"
+    input_file.write_text(
+        "---\nsource: draft\n---\nfile-input\n",
+        encoding="utf-8",
+    )
+
+    metadata = PromptMetadata(
+        key="json-echo",
+        name="JSON Echo",
+        version="1.0.0",
+        description="JSON prompt for testing.",
+        task_type="test",
+        role="task",
+        required_variables=[],
+        optional_variables=[],
+        default_variables={},
+        output_contract={"mode": "json", "schema_ref": "tnh.testing.echo.v1"},
+    )
+    stub_service = _JsonStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "json-output.json"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "json-echo",
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "succeeded"
+    assert payload["result"]["json"] == {"message": "generated"}
+    assert payload["result"]["schema_ref"] == "tnh.testing.echo.v1"
+    assert payload["result"]["text"] == '{"message":"generated"}'
+    assert output_file.read_text(encoding="utf-8") == '{"message":"generated"}'
+
+
+def test_run_api_contract_validation_failure_uses_format_error_and_skips_output_file(
+    tmp_path,
+    monkeypatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="json-echo",
+        name="JSON Echo",
+        version="1.0.0",
+        description="JSON prompt for testing.",
+        task_type="test",
+        role="task",
+        required_variables=[],
+        optional_variables=[],
+        default_variables={},
+        output_contract={"mode": "json", "schema_ref": "tnh.testing.echo.v1"},
+    )
+    stub_service = _JsonContractFailedStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "failed.json"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "json-echo",
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.FORMAT_ERROR
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert payload["failure"]["reason"] == FailureReason.CONTRACT_VALIDATION_FAILED.value
+    assert not output_file.exists()
+
+
+def test_run_api_missing_json_schema_returns_input_error(tmp_path, monkeypatch):
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    prompt_dir.joinpath("missing-schema.md").write_text(
+        dedent(
+            """\
+            ---
+            key: missing-schema
+            name: Missing Schema
+            version: 1.0.0
+            description: JSON prompt with missing schema artifact.
+            task_type: test
+            role: task
+            required_variables: []
+            output_contract:
+              mode: json
+              schema_ref: tnh.testing.missing.v1
+            ---
+            Return JSON.
+            """
+        ),
+        encoding="utf-8",
+    )
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", str(prompt_dir))
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "--api",
+            "run",
+            "--prompt",
+            "missing-schema",
+            "--input-file",
+            str(input_file),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.INPUT_ERROR
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert "Prompt contract schema 'tnh.testing.missing.v1' was not found" in payload["error"]
+
+
 def test_run_api_budget_block_returns_structured_payload(tmp_path, monkeypatch):
     _write_prompt(tmp_path)
     input_file = tmp_path / "input.txt"
@@ -1111,6 +1371,52 @@ def test_run_human_mode_failed_completion_reports_error_and_skips_output_file(tm
     assert "backend failure" in result.stdout
     assert "[warn]" in result.stderr
     assert "trace_id=" in result.stderr
+    assert not output_file.exists()
+
+
+def test_run_human_mode_contract_validation_failure_skips_output_file(
+    tmp_path,
+    monkeypatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("file-input", encoding="utf-8")
+
+    metadata = PromptMetadata(
+        key="json-echo",
+        name="JSON Echo",
+        version="1.0.0",
+        description="JSON prompt for testing.",
+        task_type="test",
+        role="task",
+        required_variables=[],
+        optional_variables=[],
+        default_variables={},
+        output_contract={"mode": "json", "schema_ref": "tnh.testing.echo.v1"},
+    )
+    stub_service = _JsonContractFailedStubService(metadata)
+
+    monkeypatch.setenv("TNH_PROMPT_DIR", prompt_dir)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TNH_GEN_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setattr(run_module, "_initialize_service", lambda *_, **__: stub_service)
+
+    output_file = tmp_path / "failed.json"
+    result = runner.invoke(
+        tnh_gen.app,
+        [
+            "run",
+            "--prompt",
+            "json-echo",
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.FORMAT_ERROR
+    assert "Generated JSON did not satisfy schema" in result.stdout
     assert not output_file.exists()
 
 

--- a/tests/cli_tools/test_tnh_gen.py
+++ b/tests/cli_tools/test_tnh_gen.py
@@ -1138,6 +1138,11 @@ def test_run_api_json_prompt_includes_structured_result_and_writes_canonical_jso
     assert payload["result"]["schema_ref"] == "tnh.testing.echo.v1"
     assert payload["result"]["text"] == '{"message":"generated"}'
     assert output_file.read_text(encoding="utf-8") == '{"message":"generated"}'
+    sidecar = Path(f"{output_file}.provenance.yaml")
+    sidecar_payload = yaml.safe_load(sidecar.read_text(encoding="utf-8"))
+    assert sidecar_payload["source"] == "draft"
+    assert sidecar_payload["tnh_scholar_generated"] is True
+    assert sidecar_payload["prompt_key"] == "json-echo"
 
 
 def test_run_api_contract_validation_failure_uses_format_error_and_skips_output_file(

--- a/tests/cli_tools/test_tnh_gen_coverage.py
+++ b/tests/cli_tools/test_tnh_gen_coverage.py
@@ -534,6 +534,31 @@ def test_provenance_write_structured_output_skips_headers_even_with_metadata(tmp
         structured_output=True,
     )
     assert output_file.read_text(encoding="utf-8") == '{"message":"ok"}'
+    sidecar = provenance_module.sidecar_path(output_file)
+    payload = yaml.safe_load(sidecar.read_text(encoding="utf-8"))
+    assert payload["source"] == "draft"
+    assert payload["tnh_scholar_generated"] is True
+
+
+def test_provenance_write_structured_output_without_generated_provenance_writes_source_sidecar(tmp_path):
+    output_file = tmp_path / "output.json"
+    envelope = _envelope_with_warnings()
+    source_metadata = Metadata({"source": "draft"})
+    provenance_module.write_output_file(
+        output_file,
+        result_text='{"message":"ok"}',
+        envelope=envelope,
+        source_metadata=source_metadata,
+        trace_id="trace",
+        prompt_version=None,
+        include_provenance=False,
+        structured_output=True,
+    )
+    assert output_file.read_text(encoding="utf-8") == '{"message":"ok"}'
+    sidecar = provenance_module.sidecar_path(output_file)
+    payload = yaml.safe_load(sidecar.read_text(encoding="utf-8"))
+    assert payload["source"] == "draft"
+    assert "tnh_scholar_generated" not in payload
 
 
 def test_load_vars_file_accepts_frontmatter_wrapped_json(tmp_path):

--- a/tests/cli_tools/test_tnh_gen_coverage.py
+++ b/tests/cli_tools/test_tnh_gen_coverage.py
@@ -523,9 +523,10 @@ def test_provenance_write_structured_output_skips_headers_even_with_metadata(tmp
     output_file = tmp_path / "output.json"
     envelope = _envelope_with_warnings()
     source_metadata = Metadata({"source": "draft"})
+    result_text = '{\n  "message": "ok"\n}'
     provenance_module.write_output_file(
         output_file,
-        result_text='{"message":"ok"}',
+        result_text=result_text,
         envelope=envelope,
         source_metadata=source_metadata,
         trace_id="trace",
@@ -533,7 +534,8 @@ def test_provenance_write_structured_output_skips_headers_even_with_metadata(tmp
         include_provenance=True,
         structured_output=True,
     )
-    assert output_file.read_text(encoding="utf-8") == '{"message":"ok"}'
+    # Structured output writes are raw passthrough; canonicalization happens upstream.
+    assert output_file.read_text(encoding="utf-8") == result_text
     sidecar = provenance_module.sidecar_path(output_file)
     payload = yaml.safe_load(sidecar.read_text(encoding="utf-8"))
     assert payload["source"] == "draft"

--- a/tests/cli_tools/test_tnh_gen_coverage.py
+++ b/tests/cli_tools/test_tnh_gen_coverage.py
@@ -519,6 +519,23 @@ def test_provenance_write_without_header(tmp_path):
     assert output_file.read_text(encoding="utf-8") == "plain text"
 
 
+def test_provenance_write_structured_output_skips_headers_even_with_metadata(tmp_path):
+    output_file = tmp_path / "output.json"
+    envelope = _envelope_with_warnings()
+    source_metadata = Metadata({"source": "draft"})
+    provenance_module.write_output_file(
+        output_file,
+        result_text='{"message":"ok"}',
+        envelope=envelope,
+        source_metadata=source_metadata,
+        trace_id="trace",
+        prompt_version=None,
+        include_provenance=True,
+        structured_output=True,
+    )
+    assert output_file.read_text(encoding="utf-8") == '{"message":"ok"}'
+
+
 def test_load_vars_file_accepts_frontmatter_wrapped_json(tmp_path):
     vars_file = tmp_path / "vars.json"
     vars_file.write_text(

--- a/tests/gen_ai_service/test_json_contract_runtime.py
+++ b/tests/gen_ai_service/test_json_contract_runtime.py
@@ -114,7 +114,7 @@ def test_gen_ai_service_validates_json_contract_and_canonicalizes_text(
     assert response_format is not None
     assert response_format["type"] == "json_schema"
     assert response_format["json_schema"]["name"] == "tnh_testing_echo_v1"
-    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["strict"] is False
     assert response_format["json_schema"]["schema"]["type"] == "object"
     assert envelope.result is not None
     assert envelope.result.json_value == {"message": "hello"}
@@ -151,3 +151,34 @@ def test_gen_ai_service_maps_schema_validation_failures_to_failed_outcome(
     assert envelope.failure is not None
     assert envelope.failure.reason == FailureReason.CONTRACT_VALIDATION_FAILED
     assert "schema 'tnh.testing.echo.v1'" in envelope.failure.message
+
+
+def test_gen_ai_service_maps_malformed_json_to_failed_outcome(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    monkeypatch.setattr(service_module, "apply_policy", _fake_apply_policy)
+    monkeypatch.setattr(service_module, "select_provider_and_model", _fake_select)
+    monkeypatch.setattr(service_module, "OpenAIClient", DummyOpenAIClient)
+    monkeypatch.setenv("TNH_PROMPT_DIR", str(prompt_dir))
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    settings = GenAISettings(_env_file=None)
+    service = GenAIService(settings=settings)
+    dummy_client: DummyOpenAIClient = service.openai_client  # type: ignore[assignment]
+    dummy_client.response = _provider_response("{not-json")
+
+    envelope = service.generate(
+        RenderRequest(
+            instruction_key="json-echo",
+            user_input="ignored",
+            variables={},
+        )
+    )
+
+    assert envelope.outcome.value == "failed"
+    assert envelope.result is None
+    assert envelope.failure is not None
+    assert envelope.failure.reason == FailureReason.CONTRACT_VALIDATION_FAILED
+    assert "not valid JSON" in envelope.failure.message

--- a/tests/gen_ai_service/test_json_contract_runtime.py
+++ b/tests/gen_ai_service/test_json_contract_runtime.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from tnh_scholar.gen_ai_service import service as service_module
+from tnh_scholar.gen_ai_service.config.params_policy import ResolvedParams
+from tnh_scholar.gen_ai_service.config.settings import GenAISettings
+from tnh_scholar.gen_ai_service.models.domain import FailureReason, RenderRequest
+from tnh_scholar.gen_ai_service.models.transport import (
+    FinishReason,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderStatus,
+    ProviderUsage,
+    TextPayload,
+)
+from tnh_scholar.gen_ai_service.service import GenAIService
+
+
+class DummyOpenAIClient:
+    def __init__(self, api_key: str | None, organization: str | None):
+        self.requests: list[ProviderRequest] = []
+        self.response: ProviderResponse | None = None
+        self.sdk_version = "openai-sdk-test"
+
+    def generate(self, request: ProviderRequest) -> ProviderResponse:
+        self.requests.append(request)
+        if self.response is None:
+            raise AssertionError("test must set DummyOpenAIClient.response")
+        return self.response
+
+
+def _write_json_prompt(tmp_path):
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    prompt_dir.joinpath("json-echo.md").write_text(
+        dedent(
+            """\
+            ---
+            key: json-echo
+            name: json-echo
+            version: 1.0.0
+            description: JSON contract prompt for testing.
+            task_type: test
+            role: task
+            required_variables: []
+            output_contract:
+              mode: json
+              schema_ref: tnh.testing.echo.v1
+            ---
+            Return a JSON object.
+            """
+        ),
+        encoding="utf-8",
+    )
+    return prompt_dir
+
+
+def _provider_response(text: str) -> ProviderResponse:
+    return ProviderResponse(
+        provider="openai",
+        model="gpt-5-mini",
+        status=ProviderStatus.OK,
+        attempts=1,
+        payload=TextPayload(text=text, finish_reason=FinishReason.STOP),
+        usage=ProviderUsage(tokens_in=5, tokens_out=4, tokens_total=9),
+    )
+
+
+def _fake_apply_policy(intent, call_hint, **_):
+    return ResolvedParams(
+        provider="openai",
+        model="gpt-5-mini",
+        temperature=0.2,
+        max_output_tokens=256,
+        output_mode="json",
+        seed=1,
+        routing_reason="test-policy",
+    )
+
+
+def _fake_select(intent, params, settings, **_):
+    return params
+
+
+def test_gen_ai_service_validates_json_contract_and_canonicalizes_text(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    monkeypatch.setattr(service_module, "apply_policy", _fake_apply_policy)
+    monkeypatch.setattr(service_module, "select_provider_and_model", _fake_select)
+    monkeypatch.setattr(service_module, "OpenAIClient", DummyOpenAIClient)
+    monkeypatch.setenv("TNH_PROMPT_DIR", str(prompt_dir))
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    settings = GenAISettings(_env_file=None)
+    service = GenAIService(settings=settings)
+    dummy_client: DummyOpenAIClient = service.openai_client  # type: ignore[assignment]
+    dummy_client.response = _provider_response('{\n  "message": "hello"\n}')
+
+    envelope = service.generate(
+        RenderRequest(
+            instruction_key="json-echo",
+            user_input="ignored",
+            variables={},
+        )
+    )
+
+    assert envelope.outcome.value == "succeeded"
+    response_format = dummy_client.requests[0].response_format
+    assert response_format is not None
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["name"] == "tnh_testing_echo_v1"
+    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["schema"]["type"] == "object"
+    assert envelope.result is not None
+    assert envelope.result.json_value == {"message": "hello"}
+    assert envelope.result.schema_ref == "tnh.testing.echo.v1"
+    assert envelope.result.text == '{"message":"hello"}'
+
+
+def test_gen_ai_service_maps_schema_validation_failures_to_failed_outcome(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_dir = _write_json_prompt(tmp_path)
+    monkeypatch.setattr(service_module, "apply_policy", _fake_apply_policy)
+    monkeypatch.setattr(service_module, "select_provider_and_model", _fake_select)
+    monkeypatch.setattr(service_module, "OpenAIClient", DummyOpenAIClient)
+    monkeypatch.setenv("TNH_PROMPT_DIR", str(prompt_dir))
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    settings = GenAISettings(_env_file=None)
+    service = GenAIService(settings=settings)
+    dummy_client: DummyOpenAIClient = service.openai_client  # type: ignore[assignment]
+    dummy_client.response = _provider_response('{"message": 1}')
+
+    envelope = service.generate(
+        RenderRequest(
+            instruction_key="json-echo",
+            user_input="ignored",
+            variables={},
+        )
+    )
+
+    assert envelope.outcome.value == "failed"
+    assert envelope.result is None
+    assert envelope.failure is not None
+    assert envelope.failure.reason == FailureReason.CONTRACT_VALIDATION_FAILED
+    assert "schema 'tnh.testing.echo.v1'" in envelope.failure.message

--- a/tests/prompt_system/test_contract_schema.py
+++ b/tests/prompt_system/test_contract_schema.py
@@ -10,6 +10,8 @@ from tnh_scholar.configuration.context import TNHContext
 from tnh_scholar.exceptions import ConfigurationError
 from tnh_scholar.prompt_system.service.contract_schema import (
     PromptContractSchemaResolver,
+    _load_schema_document,
+    _relative_schema_path,
 )
 
 
@@ -60,6 +62,14 @@ def test_schema_resolver_rejects_missing_schema(tmp_path: Path):
         PromptContractSchemaResolver(context).resolve_validated("tnh.testing.missing.v1")
 
 
+def test_schema_resolver_rejects_invalid_schema_ref_syntax():
+    with pytest.raises(ConfigurationError, match="Invalid prompt contract schema_ref"):
+        _relative_schema_path("tnh..bad.v1")
+
+    with pytest.raises(ConfigurationError, match="Invalid prompt contract schema_ref"):
+        _relative_schema_path("../escape")
+
+
 def test_schema_resolver_rejects_invalid_schema_document(tmp_path: Path):
     builtin_root = tmp_path / "builtin"
     _write_schema(builtin_root, "tnh.testing.bad.v1", {"type": 123})
@@ -73,6 +83,22 @@ def test_schema_resolver_rejects_invalid_schema_document(tmp_path: Path):
 
     with pytest.raises(ConfigurationError, match="is invalid"):
         PromptContractSchemaResolver(context).resolve_validated("tnh.testing.bad.v1")
+
+
+def test_schema_resolver_rejects_non_object_schema_document(tmp_path: Path):
+    schema_path = tmp_path / "non_object.schema.json"
+    schema_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="must be a JSON object"):
+        _load_schema_document(schema_path)
+
+
+def test_schema_resolver_rejects_malformed_json_schema_document(tmp_path: Path):
+    schema_path = tmp_path / "malformed.schema.json"
+    schema_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="is not valid JSON"):
+        _load_schema_document(schema_path)
 
 
 def test_schema_resolver_validates_json_instances(tmp_path: Path):

--- a/tests/prompt_system/test_contract_schema.py
+++ b/tests/prompt_system/test_contract_schema.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+
+from tnh_scholar.configuration.context import TNHContext
+from tnh_scholar.exceptions import ConfigurationError
+from tnh_scholar.prompt_system.service.contract_schema import (
+    PromptContractSchemaResolver,
+)
+
+
+def _write_schema(base: Path, schema_ref: str, payload: dict) -> Path:
+    relative = Path("schemas", "prompt-contracts", *schema_ref.split(".")[:-1])
+    path = base / relative / f"{schema_ref.split('.')[-1]}.schema.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_schema_resolver_uses_workspace_user_builtin_precedence(tmp_path: Path):
+    workspace_root = tmp_path / "workspace"
+    user_root = tmp_path / "user"
+    builtin_root = tmp_path / "builtin"
+    schema_ref = "tnh.testing.echo.v1"
+    workspace_schema = {"type": "object", "required": ["workspace"]}
+    user_schema = {"type": "object", "required": ["user"]}
+    builtin_schema = {"type": "object", "required": ["builtin"]}
+
+    workspace_path = _write_schema(workspace_root, schema_ref, workspace_schema)
+    _write_schema(user_root, schema_ref, user_schema)
+    _write_schema(builtin_root, schema_ref, builtin_schema)
+    context = TNHContext(
+        builtin_root=builtin_root,
+        workspace_root=workspace_root,
+        user_root=user_root,
+        correlation_id="corr",
+        session_id="sess",
+    )
+
+    resolved = PromptContractSchemaResolver(context).resolve_validated(schema_ref)
+
+    assert resolved.path == workspace_path
+    assert resolved.document == workspace_schema
+
+
+def test_schema_resolver_rejects_missing_schema(tmp_path: Path):
+    context = TNHContext(
+        builtin_root=tmp_path / "builtin",
+        workspace_root=tmp_path / "workspace",
+        user_root=tmp_path / "user",
+        correlation_id="corr",
+        session_id="sess",
+    )
+
+    with pytest.raises(ConfigurationError, match="was not found"):
+        PromptContractSchemaResolver(context).resolve_validated("tnh.testing.missing.v1")
+
+
+def test_schema_resolver_rejects_invalid_schema_document(tmp_path: Path):
+    builtin_root = tmp_path / "builtin"
+    _write_schema(builtin_root, "tnh.testing.bad.v1", {"type": 123})
+    context = TNHContext(
+        builtin_root=builtin_root,
+        workspace_root=None,
+        user_root=tmp_path / "user",
+        correlation_id="corr",
+        session_id="sess",
+    )
+
+    with pytest.raises(ConfigurationError, match="is invalid"):
+        PromptContractSchemaResolver(context).resolve_validated("tnh.testing.bad.v1")
+
+
+def test_schema_resolver_validates_json_instances(tmp_path: Path):
+    builtin_root = tmp_path / "builtin"
+    schema_ref = "tnh.testing.echo.v1"
+    _write_schema(
+        builtin_root,
+        schema_ref,
+        {
+            "type": "object",
+            "required": ["message"],
+            "additionalProperties": False,
+            "properties": {"message": {"type": "string"}},
+        },
+    )
+    context = TNHContext(
+        builtin_root=builtin_root,
+        workspace_root=None,
+        user_root=tmp_path / "user",
+        correlation_id="corr",
+        session_id="sess",
+    )
+    resolver = PromptContractSchemaResolver(context)
+    resolved = resolver.resolve_validated(schema_ref)
+
+    resolver.validate_instance(resolved, {"message": "ok"})
+
+    with pytest.raises(JsonSchemaValidationError):
+        resolver.validate_instance(resolved, {"message": 1})

--- a/tests/prompt_system/test_validator.py
+++ b/tests/prompt_system/test_validator.py
@@ -1,5 +1,7 @@
+from tnh_scholar.configuration.context import TNHContext
 from tnh_scholar.prompt_system.config.policy import ValidationPolicy
 from tnh_scholar.prompt_system.domain.models import Prompt, PromptMetadata, RenderParams
+from tnh_scholar.prompt_system.service.contract_schema import PromptContractSchemaResolver
 from tnh_scholar.prompt_system.service.validator import PromptValidator
 
 
@@ -111,6 +113,32 @@ def test_validate_rejects_json_output_without_schema_ref():
 
     assert not result.valid
     assert any(err.code == "MISSING_SCHEMA_REF" for err in result.errors)
+
+
+def test_validate_rejects_unresolvable_schema_ref(tmp_path):
+    resolver = PromptContractSchemaResolver(
+        TNHContext(
+            builtin_root=tmp_path / "builtin",
+            workspace_root=tmp_path / "workspace",
+            user_root=tmp_path / "user",
+            correlation_id="corr",
+            session_id="sess",
+        )
+    )
+    validator = PromptValidator(ValidationPolicy(), schema_resolver=resolver)
+    prompt = make_prompt(
+        metadata_extra={
+            "output_contract": {
+                "mode": "json",
+                "schema_ref": "tnh.testing.missing.v1",
+            }
+        }
+    )
+
+    result = validator.validate(prompt)
+
+    assert not result.valid
+    assert any(err.code == "INVALID_SCHEMA_REF" for err in result.errors)
 
 
 def test_validate_rejects_artifacts_output_without_artifact_declarations():


### PR DESCRIPTION
## Summary
- add prompt-contract schema resolution and validation with workspace/user/built-in precedence
- enforce JSON prompt contracts in `GenAIService` and surface structured JSON results through `tnh-gen`
- switch the OpenAI path to provider-native `json_schema` structured output requests while keeping local schema validation authoritative
- keep JSON `--output-file` writes machine-readable by skipping provenance/frontmatter headers for structured outputs
- add focused prompt-system, service, CLI, and provenance regressions for structured JSON success, failure, and missing-schema paths

## Validation
- `/Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/pytest tests/prompt_system/test_contract_schema.py tests/prompt_system/test_validator.py tests/gen_ai_service/test_json_contract_runtime.py tests/cli_tools/test_tnh_gen.py tests/cli_tools/test_tnh_gen_coverage.py -q`
- `/Users/phapman/Desktop/Projects/tnh-scholar/.venv/bin/pytest tests/gen_ai_service/test_service.py tests/cli_tools/test_tnh_gen.py tests/gen_ai_service/test_json_contract_runtime.py -q`

## Notes
- `make pr-check` and `make ci-check` both fail in this fresh worktree because Poetry resolves through a broken pyenv shim path: `Command '['/Users/phapman/.pyenv/shims/python', '-EsSc', 'import sys; print(sys.executable)']' returned non-zero exit status 127.`
- focused test suites above passed in the shared project venv despite that tooling issue.

## Summary by Sourcery

Add JSON prompt contract schema resolution, enforcement, and structured output handling across GenAI service, prompt validation, and the tnh-gen CLI.

New Features:
- Introduce prompt-contract JSON Schema resolution and validation with workspace, user, and built-in precedence for JSON prompts.
- Enforce JSON output contracts at runtime in GenAIService, including provider-native structured output requests for OpenAI and canonical JSON text in results.
- Surface structured JSON results and associated schema references from tnh-gen API responses and human-mode runs, while keeping JSON output files machine-readable.

Enhancements:
- Extend prompt validation to reject JSON prompts that reference missing or invalid schema artifacts.
- Map contract validation failures to a dedicated CONTRACT_VALIDATION_FAILED failure reason and corresponding CLI exit code, distinguishing format issues from provider errors.
- Ensure provenance writing logic skips YAML headers for structured JSON outputs, even when provenance metadata is available.

Documentation:
- Document the structured JSON contract validation behavior and related runtime assets in the changelog.

Tests:
- Add focused tests for schema precedence and instance validation, GenAIService JSON contract runtime behavior, CLI behavior for JSON prompts (success, contract failure, and missing-schema cases), and provenance handling for structured outputs.