### PR TITLE
[codex] Fix tnh-gen model-max provider token caps

### DIFF
--- a/src/tnh_scholar/gen_ai_service/models/transport.py
+++ b/src/tnh_scholar/gen_ai_service/models/transport.py
@@ -28,7 +28,7 @@ class ProviderRequest(BaseModel):
     messages: List[Message]
     system: Optional[str] = None
     temperature: float
-    max_output_tokens: int
+    max_output_tokens: int | None = None
     seed: Optional[int] = None
     reasoning_effort: Optional[str] = None
     response_format: Optional[Type[BaseModel] | Mapping[str, Any]] = None

--- a/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_adapter.py
@@ -61,7 +61,7 @@ class OpenAIChatCompletionRequest(BaseModel):
     model: str
     messages: List[ChatCompletionMessageParam]
     temperature: float | None
-    max_completion_tokens: int
+    max_completion_tokens: int | None = None
     seed: Optional[int] = None
     reasoning_effort: str | None = None
     response_format: Optional[type[BaseModel] | Mapping[str, Any]] = None

--- a/src/tnh_scholar/gen_ai_service/providers/openai_client.py
+++ b/src/tnh_scholar/gen_ai_service/providers/openai_client.py
@@ -69,9 +69,10 @@ class OpenAIClient(ProviderClient):
         request_kwargs = dict(
             model=openai_request.model,
             messages=openai_request.messages,
-            max_completion_tokens=openai_request.max_completion_tokens,
             seed=openai_request.seed,
         )
+        if openai_request.max_completion_tokens is not None:
+            request_kwargs["max_completion_tokens"] = openai_request.max_completion_tokens
         if openai_request.temperature is not None:
             request_kwargs["temperature"] = openai_request.temperature
         if openai_request.reasoning_effort is not None:

--- a/src/tnh_scholar/gen_ai_service/service.py
+++ b/src/tnh_scholar/gen_ai_service/service.py
@@ -104,7 +104,7 @@ class GenAIService:
             system=rendered.system,
             messages=rendered.messages,
             temperature=selection.temperature,
-            max_output_tokens=safety_report.effective_max_output_tokens,
+            max_output_tokens=_provider_request_max_output_tokens(safety_report),
             seed=selection.seed,
             reasoning_effort=selection.reasoning_effort,
             response_format=_response_format_for_schema(
@@ -186,6 +186,21 @@ def _build_policy_applied(
     if routing_reason is not None:
         policy["routing_reason"] = routing_reason
     return policy
+
+
+def _provider_request_max_output_tokens(
+    safety_report: safety_gate.SafetyReport,
+) -> int | None:
+    """Return the explicit provider cap to send for this request.
+
+    MODEL_MAX means "use the provider/model maximum safely available for this
+    prompt," so we avoid sending an explicit cap and let the provider enforce
+    its own current ceiling. We still keep the resolved effective budget in the
+    safety report for blocking, reporting, and cost estimation.
+    """
+    if safety_report.output_token_limit_mode is safety_gate.OutputTokenLimitMode.MODEL_MAX:
+        return None
+    return int(safety_report.effective_max_output_tokens)
 
 
 def _response_format_for_schema(

--- a/src/tnh_scholar/runtime_assets/registries/providers/openai.jsonc
+++ b/src/tnh_scholar/runtime_assets/registries/providers/openai.jsonc
@@ -3,8 +3,8 @@
   "$schema": "./schema.json",
   "schema_version": "1.0",
   "provider": "openai",
-  "last_updated": "2026-04-20",
-  "source_url": "https://openai.com/api/pricing/",
+  "last_updated": "2026-06-22",
+  "source_url": "https://developers.openai.com/api/docs/models",
   "update_method": "manual",
   "pricing_tier": "standard",
   "pricing_tier_metadata": {
@@ -46,8 +46,8 @@
         "function_calling": true,
         "streaming": true
       },
-      "context_window": 200000,
-      "max_output_tokens": 16384,
+      "context_window": 400000,
+      "max_output_tokens": 128000,
       "pricing_tiers": {
         "batch": {
           "input_per_1k": 0.000125,
@@ -85,8 +85,8 @@
         "function_calling": true,
         "streaming": true
       },
-      "context_window": 200000,
-      "max_output_tokens": 16384,
+      "context_window": 400000,
+      "max_output_tokens": 128000,
       "pricing_tiers": {
         "batch": {
           "input_per_1k": 0.000625,
@@ -124,8 +124,8 @@
         "function_calling": true,
         "streaming": true
       },
-      "context_window": 200000,
-      "max_output_tokens": 16384,
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
       "pricing_tiers": {
         "standard": {
           "input_per_1k": 0.00125,
@@ -148,8 +148,8 @@
         "function_calling": true,
         "streaming": true
       },
-      "context_window": 200000,
-      "max_output_tokens": 16384,
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
       "pricing_tiers": {
         "batch": {
           "input_per_1k": 0.000625,

--- a/tests/gen_ai_service/test_openai_adapter.py
+++ b/tests/gen_ai_service/test_openai_adapter.py
@@ -171,6 +171,22 @@ def test_openai_adapter_honors_requested_reasoning_for_gpt55_models():
     assert openai_request.reasoning_effort == "low"
 
 
+def test_openai_adapter_allows_omitting_explicit_max_completion_tokens():
+    adapter = OpenAIAdapter()
+    request = ProviderRequest(
+        provider="openai",
+        model="gpt-5.5",
+        system="sys",
+        messages=[Message(role="user", content="Return ACK")],
+        temperature=0.2,
+        max_output_tokens=None,
+    )
+
+    openai_request = adapter.to_openai_request(request)
+
+    assert openai_request.max_completion_tokens is None
+
+
 def test_openai_adapter_suppresses_reasoning_when_requested_none():
     adapter = OpenAIAdapter()
     request = ProviderRequest(

--- a/tests/gen_ai_service/test_openai_client.py
+++ b/tests/gen_ai_service/test_openai_client.py
@@ -53,3 +53,27 @@ def test_openai_client_keeps_temperature_for_gpt54_requests():
 
     assert captured["temperature"] == 0.2
     assert "reasoning_effort" not in captured
+
+
+def test_openai_client_omits_max_completion_tokens_when_unset():
+    client = OpenAIClient(api_key="test-key", organization=None)
+    captured: dict[str, object] = {}
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace()
+
+    client._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+    request = SimpleNamespace(
+        model="gpt-5.5",
+        messages=[{"role": "user", "content": "Return ACK"}],
+        temperature=None,
+        max_completion_tokens=None,
+        seed=None,
+        reasoning_effort="high",
+        response_format=None,
+    )
+
+    client._chat_create(request)
+
+    assert "max_completion_tokens" not in captured

--- a/tests/gen_ai_service/test_registry_loader.py
+++ b/tests/gen_ai_service/test_registry_loader.py
@@ -9,7 +9,8 @@ def test_openai_registry_includes_gpt54():
     model_info = loader.get_model("openai", "gpt-5.4")
 
     assert model_info.family == "gpt-5"
-    assert model_info.max_output_tokens == 16384
+    assert model_info.context_window == 1_050_000
+    assert model_info.max_output_tokens == 128_000
 
 
 def test_openai_registry_includes_gpt55():
@@ -18,5 +19,6 @@ def test_openai_registry_includes_gpt55():
     model_info = loader.get_model("openai", "gpt-5.5")
 
     assert model_info.family == "gpt-5"
-    assert model_info.max_output_tokens == 16384
+    assert model_info.context_window == 1_050_000
+    assert model_info.max_output_tokens == 128_000
     assert "gpt-5.5-latest" in model_info.aliases

--- a/tests/gen_ai_service/test_service.py
+++ b/tests/gen_ai_service/test_service.py
@@ -6,7 +6,10 @@ import pytest
 
 from tnh_scholar.exceptions import ConfigurationError
 from tnh_scholar.gen_ai_service import service as service_module
-from tnh_scholar.gen_ai_service.config.output_tokens import OutputTokenLimitPolicy
+from tnh_scholar.gen_ai_service.config.output_tokens import (
+    OutputTokenLimitMode,
+    OutputTokenLimitPolicy,
+)
 from tnh_scholar.gen_ai_service.config.params_policy import ResolvedParams
 from tnh_scholar.gen_ai_service.config.settings import GenAISettings
 from tnh_scholar.gen_ai_service.infra.tracking.fingerprint import (
@@ -164,3 +167,60 @@ def test_missing_api_key_raises_configuration_error(tmp_path, monkeypatch: pytes
 
     with pytest.raises(ConfigurationError, match="Missing required API key: OPENAI_API_KEY"):
         GenAIService(settings=settings)
+
+
+def test_gen_ai_service_omits_provider_cap_for_model_max_mode(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt_dir = _write_prompt(tmp_path)
+
+    policy_params = ResolvedParams(
+        provider="openai",
+        model="gpt-5.5",
+        temperature=0.2,
+        output_token_limit=OutputTokenLimitPolicy(mode=OutputTokenLimitMode.MODEL_MAX),
+        seed=None,
+    )
+
+    def fake_apply_policy(intent, call_hint, **_):
+        return policy_params
+
+    def fake_select(intent, params, settings, **_):
+        return params
+
+    monkeypatch.setattr(service_module, "apply_policy", fake_apply_policy)
+    monkeypatch.setattr(service_module, "select_provider_and_model", fake_select)
+    monkeypatch.setattr(service_module, "OpenAIClient", DummyOpenAIClient)
+    monkeypatch.setenv("TNH_PROMPT_DIR", str(prompt_dir))
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    settings = GenAISettings(
+        _env_file=None,
+        default_model="gpt-5.5",
+        default_output_token_limit_mode=OutputTokenLimitMode.MODEL_MAX,
+        max_dollars=10.0,
+    )
+    service = GenAIService(settings=settings)
+    dummy_client: DummyOpenAIClient = service.openai_client  # type: ignore[assignment]
+    dummy_client.response = ProviderResponse(
+        provider="openai",
+        model=policy_params.model,
+        status=ProviderStatus.OK,
+        attempts=1,
+        payload=TextPayload(text="Rendered completion", finish_reason=FinishReason.STOP),
+        usage=ProviderUsage(tokens_in=123, tokens_out=45, tokens_total=168),
+    )
+
+    render_request = RenderRequest(
+        instruction_key="daily",
+        user_input="Where should I begin?",
+        variables={"audience": "practitioners"},
+        intent="study-plan",
+    )
+
+    service.generate(render_request)
+
+    assert len(dummy_client.requests) == 1
+    provider_request = dummy_client.requests[0]
+    assert provider_request.max_output_tokens is None

--- a/tests/gen_ai_service/utils/test_token_utils.py
+++ b/tests/gen_ai_service/utils/test_token_utils.py
@@ -180,8 +180,8 @@ def test_estimate_max_completion_tokens_gpt5_family():
         model="gpt-5-mini",
     )
 
-    assert max_tokens > 150_000
-    assert max_tokens < 200_000
+    assert max_tokens > 390_000
+    assert max_tokens < 400_000
 
 
 def test_estimate_max_completion_tokens_with_negative_prompt_tokens():


### PR DESCRIPTION
## Summary
- stop sending an explicit provider `max_completion_tokens` when `tnh-gen` runs in model-max / `--no-max-tokens-limit` mode
- update the local OpenAI model registry to current GPT-5 family context and output-token limits
- adjust tests to reflect the new provider-cap behavior and larger GPT-5 token budgets

## Why
Explicitly sending a large cap for GPT-5.5 model-max runs can fail expensively when the local registry is stale or the provider path is stricter than our cached limits. This change makes model-max mean "do not force a provider cap" while preserving internal safety estimation and reporting.

## Validation
- `poetry run ruff check src/tnh_scholar/gen_ai_service/models/transport.py src/tnh_scholar/gen_ai_service/providers/openai_adapter.py src/tnh_scholar/gen_ai_service/providers/openai_client.py src/tnh_scholar/gen_ai_service/service.py tests/gen_ai_service/test_openai_adapter.py tests/gen_ai_service/test_openai_client.py tests/gen_ai_service/test_registry_loader.py tests/gen_ai_service/test_service.py`
- `poetry run mypy src/tnh_scholar/gen_ai_service/models/transport.py src/tnh_scholar/gen_ai_service/providers/openai_adapter.py src/tnh_scholar/gen_ai_service/providers/openai_client.py src/tnh_scholar/gen_ai_service/service.py tests/gen_ai_service/test_openai_adapter.py tests/gen_ai_service/test_openai_client.py tests/gen_ai_service/test_registry_loader.py tests/gen_ai_service/test_service.py`
- `poetry run pytest tests/gen_ai_service/test_openai_adapter.py tests/gen_ai_service/test_openai_client.py tests/gen_ai_service/test_registry_loader.py tests/gen_ai_service/test_service.py tests/cli_tools/test_tnh_gen.py -q`
- `poetry run pytest tests/cli_tools/test_tnh_gen_coverage.py -q`
- `poetry run pytest tests/gen_ai_service/utils/test_token_utils.py -q`
- `make ci-check`

## Summary by Sourcery

Relax provider token-cap handling for model-max generations and align OpenAI GPT-5 family limits with current provider settings.

Bug Fixes:
- Stop sending an explicit max completion token cap to the provider when output token limit mode is MODEL_MAX, avoiding failures when local limits are stale or overly strict.

Enhancements:
- Allow provider and OpenAI adapter request models to omit max output/completion token fields so calls can rely on provider defaults when appropriate.
- Update the OpenAI model registry for GPT-5.4 and GPT-5.5 to reflect current context window and maximum output token limits.
- Adjust internal token budget estimation for GPT-5 family models to match updated context and output-token capacities.

Tests:
- Extend service, adapter, client, registry, token-util, and CLI tests to cover omitted max-token caps and the updated GPT-5 token limits.